### PR TITLE
chore(deps): bump the agent-tools apm package to v0.1.1

### DIFF
--- a/.claude/rules/worktree-wip.md
+++ b/.claude/rules/worktree-wip.md
@@ -5,30 +5,17 @@ paths:
 
 # Worktree work-in-progress and stash rules
 
-Repos following these rules run more than one agent worktree session
-at a time, and every worktree shares one global `git stash` stack. An
-unqualified stash pop in one worktree can grab another worktree's
-entry. These rules keep cross-step persistence safe under that
-constraint.
+Repos following these rules run more than one agent worktree session at a time, and every worktree shares one global `git stash` stack. An unqualified stash pop in one worktree can grab another worktree's entry. These rules keep cross-step persistence safe under that constraint.
 
 ## Stash
 
-- Reach for `git rebase --autostash` instead of a manual stash when
-  you rebase a dirty worktree. It scopes the save to the rebase and
-  never touches the shared stack.
-- Never run a bare `git stash pop` or `git stash apply`. The shared
-  stack shifts indices whenever any worktree pushes, so a bare pop
-  targets whatever sits at `stash@{0}` at that instant, which may
-  belong to another session.
-- When you can't avoid a manual stash, name it with
-  `git stash push -m`, run `git stash list` right before restoring,
-  match your own message, and pop the explicit `stash@{n}`.
+- Reach for `git rebase --autostash` instead of a manual stash when you rebase a dirty worktree. It scopes the save to the rebase and never touches the shared stack.
+- Never run a bare `git stash pop` or `git stash apply`. The shared stack shifts indices whenever any worktree pushes, so a bare pop targets whatever sits at `stash@{0}` at that instant, which may belong to another session.
+- When you can't avoid a manual stash, name it with `git stash push -m`, run `git stash list` right before restoring, match your own message, and pop the explicit `stash@{n}`.
 
 ## Work-in-progress commits
 
-Prefer a throwaway work-in-progress commit over a stash for any state
-that needs to survive a rebase or a branch switch. A commit lives on
-the branch, so it stays clear of the shared stash stack entirely.
+Prefer a throwaway work-in-progress commit over a stash for any state that needs to survive a rebase or a branch switch. A commit lives on the branch, so it stays clear of the shared stash stack entirely.
 
 ```bash
 git commit -am wip --no-verify   # park work in progress
@@ -36,10 +23,4 @@ git commit -am wip --no-verify   # park work in progress
 git reset --soft HEAD~1          # unwind, restoring the staged changes
 ```
 
-The `--no-verify` flag belongs here because the pre-commit hooks
-reject an intentionally incomplete snapshot over formatting, lint,
-copyright headers, and the rest. This throwaway commit marks the one
-sanctioned exception to the project-wide no-`--no-verify` rule, and
-`git reset --soft` removes it before anything reaches history. A real
-commit that reaches the branch never carries `--no-verify`. It runs
-through the full hook suite.
+The `--no-verify` flag belongs here because the pre-commit hooks reject an intentionally incomplete snapshot over formatting, lint, copyright headers, and the rest. This throwaway commit marks the one sanctioned exception to the project-wide no-`--no-verify` rule, and `git reset --soft` removes it before anything reaches history. A real commit that reaches the branch never carries `--no-verify`. It runs through the full hook suite.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -14,30 +14,23 @@ description: >-
 
 # Commit message workflow
 
-Draft every commit message in a repo-root file named `COMMIT_AGENTMSG`
-before you run `git commit`. A gitignore entry keeps that file out of
-history, so it serves purely as a scratchpad for iterating on the
-message.
+Draft every commit message in the repo-root file `COMMIT_AGENTMSG` before you run `git commit`. A gitignore entry keeps that file out of history, so it serves purely as a scratchpad for iterating on the message.
 
-1. Write the full message (subject, body, and trailers) to
-   `COMMIT_AGENTMSG`.
+1. Write the full message (subject, body, and trailers) to `COMMIT_AGENTMSG`.
 2. Run `just lint-commit-msg` and resolve whatever it reports.
 3. Commit the validated draft with `git commit -F COMMIT_AGENTMSG`.
 
-`just lint-commit-msg` mirrors the commit-msg hook: vale under the
-commit scope (which catches AI commit tells via `ai-tells-commits`),
-cspell with the commit dictionary, commitlint for the Conventional
-Commits shape, and commit-trailers for trailer order. Running it while
-drafting surfaces problems early, rather than at the commit-msg hook
-where a late failure interrupts the commit.
+`just lint-commit-msg` mirrors the commit-msg hook:
 
-The commit-msg hook on `.git/COMMIT_EDITMSG` stays the real gate.
-`COMMIT_AGENTMSG` and its lint recipe only preview that gate, so a
-clean recipe run predicts a clean commit but never replaces the hook.
+- vale under the commit scope, which catches AI commit tells via `ai-tells-commits`
+- cspell with the commit dictionary
+- commitlint for the Conventional Commits shape
+- commit-trailers for trailer order
+
+Running it while drafting surfaces problems early, rather than at the commit-msg hook where a late failure interrupts the commit.
+
+The commit-msg hook on `.git/COMMIT_EDITMSG` stays the real gate. `COMMIT_AGENTMSG` and its lint recipe only preview that gate, so a clean recipe run predicts a clean commit but never replaces the hook.
 
 ## Preconditions
 
-This skill assumes the shared tbhb repo toolchain: a
-`just lint-commit-msg` recipe and a gitignore entry for
-`COMMIT_AGENTMSG`. If the repo lacks either, tell the user instead of
-improvising a substitute workflow.
+This skill assumes the shared tbhb repo toolchain: a `just lint-commit-msg` recipe and a gitignore entry for `COMMIT_AGENTMSG`. If the repo lacks either, tell the user instead of improvising a substitute workflow.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,17 +1,17 @@
 lockfile_version: '1'
-generated_at: '2026-08-01T10:25:34.016884+00:00'
+generated_at: '2026-08-01T13:46:51.669820+00:00'
 apm_version: 0.19.0
 dependencies:
 - repo_url: tbhb/agent-tools
   host: github.com
-  resolved_commit: 784f3502d2c59b9a356f9218dd418e42a316d615
-  resolved_ref: v0.1.0
+  resolved_commit: c8ec0e2c92cecf488e219918dea06f733a83fca0
+  resolved_ref: v0.1.1
   package_type: apm_package
   deployed_files:
   - .claude/rules/worktree-wip.md
   - .claude/skills/commit
   - .claude/skills/commit/SKILL.md
   deployed_file_hashes:
-    .claude/rules/worktree-wip.md: sha256:b78405376189bcb85cb5db7f9e8e42c9bbcc635df80ccc5b5b79011141ee691f
-    .claude/skills/commit/SKILL.md: sha256:562a94f94451b9d3a110a43902cecc7f8124cf67beb4427a4cfbd0c162949d44
-  content_hash: sha256:358447a32086b62a4d68ac50b328671ba9db4d5456eb69753e6fc009866b7078
+    .claude/rules/worktree-wip.md: sha256:0204082643d1ea505ae20eaf93e7d94dd52b65046f3e4f290ec7bbc5c6093634
+    .claude/skills/commit/SKILL.md: sha256:533f0c78cde63f97d2e27e41431fb91905fc45dd5886662fee0df3acab5f397c
+  content_hash: sha256:cfa1b565c5c4b1c35376d81ca5a62be61993be644a911794da9c0e9a57e5b613

--- a/apm.yml
+++ b/apm.yml
@@ -8,5 +8,5 @@ target:
   - claude
 dependencies:
   apm:
-    - tbhb/agent-tools#v0.1.0
+    - tbhb/agent-tools#v0.1.1
   mcp: []


### PR DESCRIPTION
## Gap

The `apm.yml` manifest pinned `tbhb/agent-tools#v0.1.0`, whose packaged
primitives were hard wrapped at roughly 70 columns. Any wording change inside a
wrapped paragraph reflowed the whole block, so diffs on the deployed rule and
skill files carried churn unrelated to the edit. Upstream `v0.1.1` (tag on
`c8ec0e2`) removes the wrapping.

## Change

- `apm.yml`: dependency bumped to `tbhb/agent-tools#v0.1.1`.
- `apm.lock.yaml`: regenerated by a real `apm install` (resolved commit
  `c8ec0e2c92cecf488e219918dea06f733a83fca0`, new content hash).
- `.claude/rules/worktree-wip.md` and `.claude/skills/commit/SKILL.md`:
  redeployed with the unwrapped content. Paragraph lines now join; the
  `SKILL.md` rewrite also turns one dense sentence into a four-item list.

Nothing under `styles/`, the test fixtures, or `CHANGELOG.md` was touched.

## Verification

- `apm install` run twice: the second pass reported the package as cached and
  left `apm.lock.yaml` byte identical (same sha256 across both runs).
- `git status --porcelain` after the second install showed only the four
  intended files.
- `git grep -i proofhouse` clean.
- Gates green in the worktree: `just lint-prose` (exit 0; 29 pre-existing
  warnings in `README.md` and `EXPERIMENTAL.md`, none in the deployed files),
  `just lint-markdown`, `just lint-spelling`, `prek run --all-files`,
  `just lint-commit-msg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
