### PR TITLE
chore(vale): drop the inert formats block and record the real parser fix

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -35,12 +35,18 @@ write-good.Passive = NO
 
 # COMMIT_AGENTMSG is the repo-root draft `mise run lint-commit-msg` reads,
 # and SQUASH_AGENTMSG the one `mise run lint-squash-msg` reads before a
-# squash merge. None of the three carries a suffix, so each needs the
-# Markdown parser named explicitly.
-[formats]
-COMMIT_EDITMSG = md
-COMMIT_AGENTMSG = md
-SQUASH_AGENTMSG = md
+# squash merge. None of the three carries a suffix, and vale keys [formats]
+# on a file extension, so no entry here can name a parser for them:
+# `COMMIT_AGENTMSG = md`, `.COMMIT_AGENTMSG = md`, and `* = md` each leave
+# the buffer parsed as plain text. This file used to carry a [formats] block
+# claiming otherwise. It was inert on every path that runs, and its comment
+# is where the wrong assumption reached the repotools vale-commit-msg hook.
+#
+# Plain-text parsing is why a backticked CLI flag still trips DoubleHyphen
+# in a commit message while it stays clean in a document: nothing strips the
+# code span, so the backticks are ordinary characters. The parser has to be
+# named at the vale invocation with `--ext=.md`, which the hook owns rather
+# than this file. See TODO.md.
 
 # The glob covers the drafting paths and the buffer git hands the hook,
 # each in the root and .git/ form the tools use. A squash message becomes

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,19 @@
 
 ## AIAdjectiveNounPairs: promote from warning to error
 
-`AIAdjectiveNounPairs` stays at `warning` level pending false positive
-calibration on real prose. Once the false positive rate drops enough, promote
-it to `error` to match all other rules.
+`AIAdjectiveNounPairs` stays at `warning` level pending false positive calibration on real prose. Once the false positive rate drops enough, promote it to `error` to match all other rules.
 
 - [ ] Collect false positive data on real technical documentation
 - [ ] Decide whether to remove any adjectives from the token list
 - [ ] Promote from `warning` to `error` in `styles/ai-tells/AIAdjectiveNounPairs.yml`
 - [ ] Update README rule table description: remove "Currently at `warning` level" note
+
+## vale-commit-msg: name the Markdown parser with `--ext=.md`
+
+A commit message reaches vale as a buffer with no file extension, so vale parses it as plain text and never strips code spans. A CLI flag inside a code span trips `ai-tells.DoubleHyphen` in a commit message while the same text stays clean in a document, which contradicts the rule's own message. `.vale.ini` cannot repair this: vale keys `[formats]` on a file extension, and `COMMIT_AGENTMSG = md`, `.COMMIT_AGENTMSG = md`, and `* = md` all leave the buffer as plain text.
+
+The fix is `--ext=.md` on the vale invocation in the `vale-commit-msg` hook in `repotools`, alongside the `--path` that already selects the scope. It preserves that scope. The `ai-tells-commits` rules and a bare `--` both still fire, and only the flag inside the code span stops. Handed to an in-progress `repotools` session on 2026-08-03.
+
+- [ ] Land `--ext=.md` in the upstream `scripts/vale-commit-msg.sh`, and correct its comment claiming `[formats]` resolves the parser
+- [ ] Move this repo's `.pre-commit-config.yaml` rev and `apm.yml` pin onto the tag carrying it
+- [ ] Check that `--all-files` inside a code span survives `mise run lint-commit-msg` afterwards


### PR DESCRIPTION
## Summary

The `[formats]` block in `.vale.ini` never gave commit-message drafts the Markdown parser it named, so it goes, and a comment in its place records why no entry there can work. The repository's todo list gains the upstream fix that does work, and its first paragraph loses its hard wrapping because `guard-markdown` refuses a write to a file still holding one.

## Why

Vale resolves a parser from a file extension. A commit buffer carries none, and the drafting files carry no suffix either, so every spelling of the entry leaves the message parsed as plain text. Vale reports the same findings with the block and without it.

Plain-text parsing has a visible consequence. Nothing strips a code span, so a command-line flag inside one trips `ai-tells.DoubleHyphen` in a commit message while the same text stays clean in a document. The rule's own message tells the author to wrap the flag in backticks, which holds for prose and fails here.

The parser has to arrive as an `--ext=.md` flag on the vale invocation, which belongs to the `vale-commit-msg` hook in `repotools` rather than to this file. That makes the comment the more consequential half of what goes, since the wrong mechanism it described is what reached the hook upstream.

## Verification

`mise run lint-markdown` found no issues across the tree. `mise run lint-prose` reports no errors. The new todo section draws two warning-level findings, one on `CLI` and one on a passive construction, the level this repo runs at rather than the level it gates on.

To test whether the block did anything, a commit draft at the repository root went through vale twice, with the old block appended back between the runs. Both reported the same two findings, on the file-argument path and on the standard-input path the hook drives.

Then the fix. `vale --path=COMMIT_AGENTMSG` flags a command-line flag inside a code span. Adding `--ext=.md` leaves it clean, and a bare double hyphen still fires, so the scope survives.

One caveat came out of that probing, so the recheck stays an open item on the todo list rather than a claim here. A message whose only double hyphen sits inside a code span comes back clean, which is the reported case. A message that also carries a bare double hyphen elsewhere draws a second finding whose position points inside the code span, an offset-mapping defect in vale rather than anything about the commit subject.

## Risk

Small, and contained to lint configuration. The block was inert, so removing it changes no finding on any path. If something did depend on it, restoring the block is the whole rollback and no rule file moves.

## Related

The upstream work belongs to the `vale-commit-msg` hook in `repotools`, along with correcting the comment there that claims `[formats]` resolves the parser. This repository then moves its `.pre-commit-config.yaml` rev and `apm.yml` pin onto the tag carrying it. No issue tracks it here.
