### PR TITLE
build: move the agent output template into the core package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ That hook stage is the real gate. `mise run lint-commit-msg` only previews it, s
 
 The toolchain defaults to the agent template: `mise run lint-prose`, `mise run lint-messages`, and the vale pre-commit hook all pass `--output=ai-tells-agent.tmpl`. Name the flag yourself only when invoking `vale` directly. The template prints one self-contained line per finding (location, severity, rule, the exact matched text, and the replacement parameter when the rule defines one) plus a totals line, so you can apply fixes without re-reading context through separate commands. Empty output means a clean run, and the exit code carries the result.
 
-The template is tracked at `styles/config/templates/ai-tells-agent.tmpl`, which puts it inside the `ai-tells-experimental` release zip alongside the Tengo scripts.
+`ai-tells.zip` carries the template, tracked here at `styles/config/templates/ai-tells-agent.tmpl`, so a repository syncing the core style alone can name the flag. A `vale sync` puts it under `StylesPath/config/templates/`, where vale looks up an `--output` name.
+
+Treat the output shape as a published interface. The prose-fix skills in [`repotools`](https://github.com/tbhb/repotools) parse it: they count findings with `grep -c '^[0-9]'` and read the `replace_with=` field to apply a correction. Reshaping a line or renaming a field breaks those skills and anything else reading the format, so a change there is a breaking change for consumers rather than a local edit.
 
 ## Drafting a document
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- vale off -->
+
+### Changed
+
+- **Packaging**: `ai-tells.zip` now takes the wrapper shape (a
+  top-level directory holding a `styles/` subtree) that
+  `ai-tells-experimental.zip` already used, and carries
+  `styles/config/templates/ai-tells-agent.tmpl`. A `vale sync` lands
+  the styles at `StylesPath/ai-tells/` from either shape and the
+  template at `StylesPath/config/templates/`, so
+  `--output=ai-tells-agent.tmpl` resolves for a repository syncing the
+  core style alone. The template used to ship only in the opt-in
+  experimental package, where a consumer without it got a template
+  runtime error rather than a report. `ai-tells-experimental.zip` no
+  longer carries the file, which leaves one publisher per path and no
+  way for two copies to disagree. `ai-tells-commits.zip` is unchanged.
+  Existing pins name a release, so a consumer sees the new layout on
+  its next version bump.
+
+<!-- vale on -->
+
 ## [1.28.0] - 2026-08-02
 
 <!-- vale off -->

--- a/mise.toml
+++ b/mise.toml
@@ -328,24 +328,30 @@ vale --config=.vale-test.ini test-false-positives.md && echo "Clean -- no false 
 
 # --- Package ---
 
-# Build the three release zips. ai-tells and ai-tells-commits are style-only
-# packages and zip flat, so their layout matches what every consumer's `vale
-# sync` already expects. ai-tells-experimental needs the wrapper shape (a
-# top-level dir holding a styles/ subtree) because its Tengo scripts live
-# under styles/config, and that is also where the agent output template rides
-# along. The project vocabulary and the dev-only message view stay out of the
-# package. pkg/ and the zips are gitignored build output.
+# Build the three release zips. ai-tells-commits is style-only and zips flat.
+# The other two take the wrapper shape (a top-level dir holding a styles/
+# subtree) because each carries a file under styles/config that a flat zip
+# has no room for: the agent output template in ai-tells, the Tengo scripts
+# in ai-tells-experimental. Every file under styles/config ships from exactly
+# one package, so the two copies can never diverge; the template used to ride
+# along in ai-tells-experimental, which left it out of reach of a consumer
+# syncing the core style alone. The project vocabulary and the dev-only
+# message view stay out of both. pkg/ and the zips are gitignored build
+# output.
 [tasks.build-package]
 description = "Build the three release zips"
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
 rm -rf pkg ai-tells.zip ai-tells-commits.zip ai-tells-experimental.zip
-(cd styles && zip -r ../ai-tells.zip ai-tells)
+mkdir -p pkg/ai-tells/styles/config
+cp -r styles/ai-tells pkg/ai-tells/styles/
+cp -r styles/config/templates pkg/ai-tells/styles/config/
+(cd pkg && zip -r ../ai-tells.zip ai-tells)
 (cd styles && zip -r ../ai-tells-commits.zip ai-tells-commits)
 mkdir -p pkg/ai-tells-experimental/styles
 cp -r styles/ai-tells-experimental pkg/ai-tells-experimental/styles/
-rsync -a --exclude='vocabularies/' --exclude='views/' styles/config/ pkg/ai-tells-experimental/styles/config/
+rsync -a --exclude='vocabularies/' --exclude='views/' --exclude='templates/' styles/config/ pkg/ai-tells-experimental/styles/config/
 (cd pkg && zip -r ../ai-tells-experimental.zip ai-tells-experimental)
 echo "Built ai-tells.zip, ai-tells-commits.zip, ai-tells-experimental.zip"
 '''


### PR DESCRIPTION
## Summary

`ai-tells.zip` now carries `styles/config/templates/ai-tells-agent.tmpl` and takes the wrapper shape that `ai-tells-experimental.zip` already used, so a `vale sync` lands the template under `StylesPath/config/templates/`. The experimental package no longer carries it. AGENTS.md records the template's output shape as an interface other tools read.

## Why

Vale resolves an `--output` name under the styles path. Until now the template lived in the opt-in experimental package alone. A repository syncing the core style had no such file, so vale printed a template runtime error on standard error instead of a report. A caller that discards standard error read that as a clean document. The failure looked like a pass. The prose-fix skills in [`repotools`](https://github.com/tbhb/repotools) are about to name the template by default, which puts every consumer of the core style in that position.

A flat zip has room for the style directory and nothing else, so carrying a file under `styles/config` means the core package moves to the wrapper shape. Dropping the template from the experimental package leaves one publisher per path under `styles/config`, so two installed copies cannot disagree.

## Verification

`mise run build-package` writes the three zips, and `unzip -l` confirms the core zip holds the template under its wrapper directory and the experimental zip holds no template at all. In a scratch directory pinning only the core zip, `vale sync` installs the styles under the styles path and `vale --output=ai-tells-agent.tmpl` renders a finding in the agent format rather than failing. Syncing both zips together installs the scripts and the template side by side. `mise run lint` and `mise run test` pass.

## Risk

A consumer whose `Packages` line points at a built zip rather than a release asset picks up the new core layout immediately. A `vale sync` handles either shape, so the styles install under `StylesPath/ai-tells/` as before. Existing pins name a release, so they see the change at their next version bump. If the layout turns out wrong, revert the commit and rebuild: the packaging lives entirely in the `build-package` task, and no rule file moved.

## Related

None
