### PR TITLE
chore(skills): let a model run a release end to end

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: release
-description: Perform a vale-ai-tells release end-to-end
-disable-model-invocation: true
+description: Cut a vale-ai-tells release end-to-end. Versions the changelog entry, bumps the package pins in the README, commits through the commit skill, tags, and waits for the workflow that publishes the three zips. Use when the operator asks to release, tag, or publish a version of this repository, and when a task ends in one.
 argument-hint: [vX.Y.Z]
-allowed-tools: Bash, Read, Edit
+allowed-tools: Bash, Read, Edit, Skill
 ---
 
 # Release
@@ -15,8 +14,7 @@ Perform a full release for version $ARGUMENTS.
 - Run `git status`. Working directory must show no changes and stay on `main`.
 - Run `git log --oneline -3`. Confirm the tip commit matches what you want tagged.
 - Check version format: must match `vMAJOR.MINOR.PATCH`
-- Get the previous version tag for use in step 4:
-  `git tag --sort=-version:refname | grep "^v" | head -1`
+- Get the previous version tag for use in step 4: `git tag --sort=-version:refname | grep "^v" | head -1`
 
 <!-- vale Google.Headings = NO -->
 
@@ -24,32 +22,19 @@ Perform a full release for version $ARGUMENTS.
 
 Read CHANGELOG.md and make these edits:
 
-1. Replace `## [Unreleased]` with `## [$ARGUMENTS_NO_V] - YYYY-MM-DD`,
-   using today's date. The heading uses the version without the leading
-   `v` to match the existing convention and to match the link reference
-   added in step 3 (rumdl will report `MD053 Unused link/image reference`
-   if the two get out of sync).
+1. Replace `## [Unreleased]` with `## [$ARGUMENTS_NO_V] - YYYY-MM-DD`, using today's date. The heading uses the version without the leading `v` to match the existing convention and to match the link reference added in step 3 (rumdl will report `MD053 Unused link/image reference` if the two get out of sync).
 2. Insert a new empty `## [Unreleased]` section before it
-3. Add a comparison link at the bottom of the file, before the current top link:
-   `[$ARGUMENTS_NO_V]: https://github.com/tbhb/vale-ai-tells/compare/PREV_TAG...$ARGUMENTS`
-   where PREV_TAG refers to the tag found in step 1 and ARGUMENTS_NO_V strips the leading `v`
+3. Add a comparison link at the bottom of the file, before the current top link: `[$ARGUMENTS_NO_V]: https://github.com/tbhb/vale-ai-tells/compare/PREV_TAG...$ARGUMENTS` where PREV_TAG refers to the tag found in step 1 and ARGUMENTS_NO_V strips the leading `v`
 
-**Writing CHANGELOG entries**: `Metacommentary` uses `scope: raw`,
-which bypasses `<!-- vale off -->` inline suppression. Don't quote literal
-trigger phrases from that rule (the `Let's [verb]` patterns) in the
-CHANGELOG. Paraphrase them instead, as in v1.4.0.
+**Writing CHANGELOG entries**: `Metacommentary` uses `scope: raw`, which bypasses `<!-- vale off -->` inline suppression. Don't quote literal trigger phrases from that rule (the `Let's [verb]` patterns) in the CHANGELOG. Paraphrase them instead, as in v1.4.0.
 
 ## 3. Update README.md
 
 <!-- vale Google.Headings = YES -->
 
-The release workflow builds three packages at every tag
-(`ai-tells.zip`, `ai-tells-commits.zip`, `ai-tells-experimental.zip`).
-Bump the version in every `releases/download/vX.Y.Z/...` URL in the
-README so all package references point at the new tag.
+The release workflow builds three packages at every tag (`ai-tells.zip`, `ai-tells-commits.zip`, `ai-tells-experimental.zip`). Bump the version in every `releases/download/vX.Y.Z/...` URL in the README so all package references point at the new tag.
 
-Use `grep -n "releases/download" README.md` to enumerate every
-occurrence before editing.
+Use `grep -n "releases/download" README.md` to enumerate every occurrence before editing.
 
 ## 4. Pre-commit checks
 
@@ -60,20 +45,9 @@ Run:
 
 ## 5. Commit
 
-Stage only `CHANGELOG.md` and `README.md`:
+Invoke the `commit` skill, telling it to stage `CHANGELOG.md` and `README.md` and nothing else, and to use `chore: release $ARGUMENTS` as the subject. That skill owns the `COMMIT_AGENTMSG` draft, the `Assisted-by` and `Signed-off-by` trailers the `commit-trailers` hook requires, and the gates. A hand-written `git commit` here fails that hook, since a bare subject carries no trailers.
 
-```sh
-git add CHANGELOG.md README.md
-```
-
-Keep the commit message **short and trigger-free**. The commit-msg hook lints it
-with all ai-tells rules. Use:
-
-```text
-chore: release $ARGUMENTS
-```
-
-Never include the names of flagged phrases or tokens in the commit message body.
+Keep the body **short and trigger-free**. The commit-msg hook lints the message with all ai-tells rules, and a release commit has little to explain beyond the version. Never name a flagged phrase or token in it.
 
 ## 6. Publish
 
@@ -83,9 +57,7 @@ Run:
 mise run release $ARGUMENTS
 ```
 
-This creates the annotated tag (using `-a -m`), pushes the
-commit and tag, then waits for the GitHub Actions release workflow to complete.
-It extracts the CHANGELOG entry and updates the release notes automatically.
+This creates the annotated tag (using `-a -m`), pushes the commit and tag, then waits for the GitHub Actions release workflow to complete. It extracts the CHANGELOG entry and updates the release notes automatically.
 
 ## 7. Verify
 
@@ -93,5 +65,4 @@ Run `gh release view $ARGUMENTS` to confirm:
 
 - Release notes match the CHANGELOG entry
 - The "Full Changelog" comparison link appears and points to the right range
-- All three package assets appear in the release:
-  `ai-tells.zip`, `ai-tells-commits.zip`, `ai-tells-experimental.zip`
+- All three package assets appear in the release: `ai-tells.zip`, `ai-tells-commits.zip`, `ai-tells-experimental.zip`


### PR DESCRIPTION
## Summary

The release skill loses `disable-model-invocation`, so a session already holding the authority to release can carry one out rather than handing back to the operator. Its description grows to something a model can match a request against. Step 5 now routes the commit through the `commit` skill instead of a hand-written `git commit`, and `allowed-tools` gains `Skill` so that call resolves.

## Why

A skill that answers only to a typed name stops a session at the point the release exists to reach. Lifting the flag by itself would have handed a model a procedure it cannot follow, though. Step 5 told the caller to stage two paths and write `chore: release vX.Y.Z` as the entire message, and the `commit-trailers` hook rejects a message carrying no sign-off. That instruction predates the `COMMIT_AGENTMSG` contract in `AGENTS.md`, and nobody revised it afterwards. The `commit` skill already owns the draft file, the trailers, and the gates, so step 5 calls it.

Unwrapping the paragraphs was not a choice. `guard-markdown` refuses any write to a file that still holds a hard-wrapped paragraph, so the header block could not change while the body kept its old line breaks.

## Verification

`mise run lint` passes, and `mise run repotools:lint-markdown` reports no issues across the tree. Running `guard-markdown .claude/skills/release/SKILL.md` prints nothing. The `.vale.ini` section covering `.claude/skills/**/*.md` sets an empty `BasedOnStyles`, so vale reads this file under no style and `rumdl` plus `cspell` are what judge its prose. Nobody cut a release from the revised procedure here. That runs at a real tag.

## Risk

A model can now begin a release on its own, which is the point and also the exposure. `mise run release` pushes a tag and starts the publish workflow, and undoing that means deleting the tag and the GitHub release by hand. Putting `disable-model-invocation: true` back at the top of the skill file restores the old behavior in one line. Should the rewritten step 5 misfire, it fails at the `commit-trailers` hook, which is where the old wording failed too.

## Related

None.
