### PR TITLE
docs(todo): swap the closed parser item for the code span defect

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,12 +9,20 @@
 - [ ] Promote from `warning` to `error` in `styles/ai-tells/AIAdjectiveNounPairs.yml`
 - [ ] Update README rule table description: remove "Currently at `warning` level" note
 
-## vale-commit-msg: name the Markdown parser with `--ext=.md`
+## Vale reports a punctuation match inside a masked code span
 
-A commit message reaches vale as a buffer with no file extension, so vale parses it as plain text and never strips code spans. A CLI flag inside a code span trips `ai-tells.DoubleHyphen` in a commit message while the same text stays clean in a document, which contradicts the rule's own message. `.vale.ini` cannot repair this: vale keys `[formats]` on a file extension, and `COMMIT_AGENTMSG = md`, `.COMMIT_AGENTMSG = md`, and `* = md` all leave the buffer as plain text.
+Vale masks a Markdown code span before matching, replacing what it holds with asterisks. A rule whose token is punctuation still draws a finding at the raw position inside the span, though only when that same token also matches elsewhere in the same paragraph. Reduced with one throwaway rule on token `\+\+` at `nonword: true`:
 
-The fix is `--ext=.md` on the vale invocation in the `vale-commit-msg` hook in `repotools`, alongside the `--path` that already selects the scope. It preserves that scope. The `ai-tells-commits` rules and a bare `--` both still fire, and only the flag inside the code span stops. Handed to an in-progress `repotools` session on 2026-08-03.
+- Inside a code span only: nothing, so the mask does its job.
+- Inside a span and once outside, same paragraph: two findings, the extra one pointing inside the span.
+- That same pair split across two paragraphs: one finding, correctly placed.
+- Outside only: one finding, correctly placed.
 
-- [ ] Land `--ext=.md` in the upstream `scripts/vale-commit-msg.sh`, and correct its comment claiming `[formats]` resolves the parser
-- [ ] Move this repo's `.pre-commit-config.yaml` rev and `apm.yml` pin onto the tag carrying it
-- [ ] Check that `--all-files` inside a code span survives `mise run lint-commit-msg` afterwards
+Paragraphs bound this, not lines. Moving the loose token down a line keeps the extra finding, and only a blank line clears it.
+
+The `nonword` setting does not cause this. The same experiment with a word token draws one correctly placed finding under `nonword: true` and under the default. Punctuation is what separates the two, and `ai-tells.DoubleHyphen` carries `nonword` only so its token can match at all.
+
+A commit message meets this through `DoubleHyphen`. One that names a command-line flag in a code span and also holds a loose pair of hyphens elsewhere draws a finding on the flag that no rewording of the flag clears. The parser work that made code spans mask at all is part of `repotools` v0.4.0, which this repo now pins, so this is what remains of it.
+
+- [ ] Report it to vale upstream with the reduced case recorded here
+- [ ] Decide whether `ai-tells` can narrow the token usefully, or whether the rule waits on a vale fix


### PR DESCRIPTION
## Summary

The todo entry tracking the commit-message parser work is replaced by one recording a vale defect: a punctuation rule draws a finding at the raw position inside a Markdown code span that vale has already masked.

## Why

Every item the old entry tracked has an answer. The `--ext=.md` flag reached the vale-commit-msg hook upstream, the comment there misstating how a format entry resolves the parser is gone, and this repository pins the release carrying both. The recheck meant to close the entry did not come back clean, though. It turned up a defect that the parser fix left behind, so the entry records that in place of work already finished.

The entry rules out the `nonword` setting by name. That was the obvious suspect, and a reader who found the entry silent on it would spend the same afternoon ruling it out again. A word token draws one correctly placed finding whether `nonword` is set or left at the default, so punctuation is what separates the two cases, and `ai-tells.DoubleHyphen` sets `nonword` only so a hyphen pair can match at all. Nothing in this repository can act on that yet. A rule sees no difference between the two positions, so the entry asks for an upstream report rather than a token change.

The entry also names the paragraph as what bounds the misplacement, rather than the line. Naming the paragraph gives the upstream report a block to point at instead of a guess at the unit, and it fits vale blocking a document before it matches anything.

## Verification

`mise run lint-draft` over the changed file runs vale, cspell, and rumdl together. cspell and rumdl come back clean. Vale returns one warning-level finding, `ai-tells-experimental.SentenceStartRepetition`, against the section's prose, where the word "The" opens several sentences. The rule counts sentence openings and drops list lines before it does, so the bullets are not what draws it. Those openings stay as written: each of the sentences names what its paragraph is about, and varying the first word moves the subject off the front. `mise run lint-prose` reports no errors.

The reduced case came from a throwaway rule on token `\+\+`, run over documents that move the loose pair around relative to the code span. Putting the loose pair on the line after the span leaves the extra finding in place, and only a blank line between the two clears it, which is what puts the boundary at the paragraph.

`mise run lint-commit-msg` shows the same behavior reaching a commit message through `ai-tells.DoubleHyphen`, since it fires the commit-msg hook stage a real commit does. A message naming a command-line flag inside a code span and holding no loose pair of hyphens passes. Adding a loose pair draws findings on both, one of them pointing inside the span at text vale had masked.

## Risk

Documentation only, so nothing in the styles or the toolchain moves. Everything here rests on the parser items being closed for real: were the pin or the upstream comment fix not actually in place, this would drop live work off the list. Reverting the commit restores the old entry whole.

## Related

The upstream flag and the corrected comment are part of `repotools` v0.4.0. This repository moved onto that tag in #11, which set both the pre-commit rev and the APM pin. No issue tracks the vale defect yet. Opening one upstream is the entry's first item.
