### PR TITLE
build(deps): move every `repotools` pin to v0.7.0 and drop the just pin

### DIFF
--- a/.claude/skills/merge-pr/SKILL.md
+++ b/.claude/skills/merge-pr/SKILL.md
@@ -78,7 +78,7 @@ bash .claude/skills/merge-pr/scripts/squash-message.sh <number>
 
 That prints a briefing and writes a skeleton. Nothing in it converts the description into a message, because no rewriting rule produces one. What merges here is the single commit a whole branch leaves behind, so writing it means reading everything that landed and deciding what a reader years from now still needs.
 
-Your briefing carries the description as published, every commit message the squash collapses in full, the diffstat, and the trailers those commits carry. Read it before writing a word. Commit bodies matter most. Each one already argued for itself once, and this is the last place that argument survives.
+Your briefing carries the description as published, every commit message the squash collapses in full, the diffstat, and the trailers those commits carry. Read it before writing a word. Commit bodies matter most. Each one already argued for itself once, and this is the last place that argument survives. Run the command on its own and read the whole thing. Piping it through `head` or `tail` keeps the trailing skeleton and drops those bodies, which nothing else in this workflow prints, and the script caps nothing on purpose, so a cap you add is one nobody downstream can see you added.
 
 `SQUASH_AGENTMSG` at the repository root holds the skeleton, which a gitignore entry keeps out of history. Subject and footer come filled in. The body stays empty until you write it.
 
@@ -125,6 +125,8 @@ Invoke the `review-squash-message` skill, passing the repository root as its arg
 This step is mandatory, and the merge script enforces it. A clean verdict signs the exact bytes of the draft, a finding erases any earlier signature, and editing the draft afterward voids it the same way.
 
 Fix everything it returns. Push back only where it's demonstrably wrong about the commits, and say why.
+
+A finding names one instance rather than the fault itself. Fix the instance, then read the rest of the message for the same fault, because a reviewer that found one instance finds the next one on the next round.
 
 ## Step 5: run the commit-msg gates
 

--- a/.claude/skills/merge-pr/tokens.json
+++ b/.claude/skills/merge-pr/tokens.json
@@ -37,10 +37,10 @@
   "bundled_files_tokens": 13742,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 3369,
-    "bytes": 11267,
+    "body_tokens": 3520,
+    "bytes": 11765,
     "frontmatter_tokens": 445,
-    "tokens": 3818
+    "tokens": 3969
   },
   "model": "claude-opus-5",
   "skill": "merge-pr"

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -86,7 +86,11 @@ Its verdict drives a loop:
 - `VERDICT: PASS` ends the loop. Go on to step 5.
 - `VERDICT: CHANGES REQUIRED` sends the findings back to `write-pr-description`, verbatim, in its arguments. Then review again.
 
-Bound it at three rounds. Past that, stop, and report which findings keep coming back, because a fourth pass at the same objection rarely resolves it.
+Bound it at three rounds, counting only the rounds a finding caused. A round the branch caused doesn't count against the bound. A remediation commit or a rebase changes what the description has to describe, and the reviewer then reads a branch it has never seen. Say which kind each round was as you go, so the count stays honest.
+
+Past three, stop rather than opening a fourth. Report the count out loud along with the findings that keep coming back, and let the operator decide whether to go on.
+
+A bound nobody reports is one nobody notices breaking.
 
 This step is mandatory, and `create-pr.sh` enforces it. A clean verdict signs the exact bytes of the draft, a finding erases any earlier signature, and a later edit voids it the same way.
 

--- a/.claude/skills/pr/tokens.json
+++ b/.claude/skills/pr/tokens.json
@@ -37,10 +37,10 @@
   "bundled_files_tokens": 21448,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 3394,
-    "bytes": 10943,
+    "body_tokens": 3514,
+    "bytes": 11346,
     "frontmatter_tokens": 422,
-    "tokens": 3820
+    "tokens": 3940
   },
   "model": "claude-opus-5",
   "skill": "pr"

--- a/.claude/skills/review-pr-description/SKILL.md
+++ b/.claude/skills/review-pr-description/SKILL.md
@@ -88,6 +88,14 @@ Judge the branch, not the description.
 - A change plus its tests, or a change plus the documentation describing it, counts as one change. Leave that alone.
 - Size alone isn't a finding. A wide mechanical rename counts as one change. A small diff touching two unrelated subsystems doesn't.
 
+## Sweep before you write the verdict
+
+A fault you found once is rarely alone. Take each finding you have and read the whole draft again for the same fault. A list that stops short of the diff, a claim scoped wider than the evidence, a count standing where a name belongs, a sentence selling rather than saying. Where the draft holds one, look for the second. Where instances share a fix, report them as a single finding naming each.
+
+Do this even when a finding sends you back into a section you already cleared. The draft in front of you changed since the last pass, and a claim that held then may not hold now.
+
+An instance you leave for the next pass costs a writer round and a reviewer round to say what this verdict could have said. None of that invites padding. Everything in the verdict still has to be something you can point at.
+
 ## What to return
 
 Your verdict is what lets the pull request proceed. A hook on the caller's side reads the line below and signs the draft you cleared. Keep the wording exact, because a verdict that hook can't parse leaves the pull request blocked. Write nothing to disk yourself, and don't edit the draft to make it pass. Reporting the finding is the job.

--- a/.claude/skills/review-pr-description/tokens.json
+++ b/.claude/skills/review-pr-description/tokens.json
@@ -6,10 +6,10 @@
   "bundled_files_tokens": 0,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 1889,
-    "bytes": 6126,
+    "body_tokens": 2131,
+    "bytes": 6966,
     "frontmatter_tokens": 172,
-    "tokens": 2065
+    "tokens": 2307
   },
   "model": "claude-opus-5",
   "skill": "review-pr-description"

--- a/.claude/skills/review-prose-fix/SKILL.md
+++ b/.claude/skills/review-prose-fix/SKILL.md
@@ -67,6 +67,12 @@ The rule set names a few figurative verbs and misses the category around them.
 
 The mechanical check already reports this, so read its output rather than re-deriving it. A `linter-config-changed` or `suppression-comment` finding there is automatically `CHANGES REQUIRED`.
 
+## Sweep before you write the verdict
+
+One editing pass produces one class of damage in more than one place at once, because the writer cleared a rule the same way everywhere it fired. Take each finding you have and read the rest of the diff for the same damage. A pronoun the reorder stranded, a clause a reword reattached to the wrong thing, an identifier paraphrased away, a parallel the edit broke on one item and kept on the next. Where the diff holds one, look for the second.
+
+Report every instance. Handing back one at a time costs a fixing round and a review round to say what this verdict could have said, and the writer only sweeps the list you give it.
+
 ## What to return
 
 Return the verdict block and stop there. Skip the preamble, the summary of the diff, and the praise. Write nothing to disk, and don't edit the document to make it pass. Reporting the finding is the job.

--- a/.claude/skills/review-prose-fix/tokens.json
+++ b/.claude/skills/review-prose-fix/tokens.json
@@ -6,10 +6,10 @@
   "bundled_files_tokens": 0,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 1290,
-    "bytes": 3956,
+    "body_tokens": 1493,
+    "bytes": 4622,
     "frontmatter_tokens": 72,
-    "tokens": 1366
+    "tokens": 1569
   },
   "model": "claude-opus-5",
   "skill": "review-prose-fix"

--- a/.claude/skills/review-squash-message/SKILL.md
+++ b/.claude/skills/review-squash-message/SKILL.md
@@ -83,6 +83,12 @@ The body answers why the branch exists. The diff already carries what changed.
 - Flag a `Closes` reference to something this branch doesn't close, and a missing one the description asked for. A cross-repository reference reduced to a bare number closes an unrelated local issue on merge.
 - Flag a missing `Signed-off-by`, or an `Assisted-by` sitting after it rather than before.
 
+## Sweep before you write the verdict
+
+A gap you found once is rarely the only one. Take each finding you have and read the whole message again for the same kind of gap. A commit whose reason went missing, a claim the branch has outgrown, a count standing where a name belongs, a paragraph restating the diff. Where the message holds one, look for the second, and where instances share a fix, report them as a single finding naming each.
+
+A gap you leave for the next pass costs a drafting round and a review round to say what this verdict could have said. None of that invites padding. Everything in the verdict still has to be something you can point at in the commits.
+
 ## What to return
 
 Your verdict is what lets the merge proceed. A hook on the caller's side reads the line below and signs the draft you cleared. Keep the wording exact, because a verdict that hook can't parse leaves the merge blocked. Write nothing to disk yourself, and don't edit the draft to make it pass. Reporting the finding is the job.

--- a/.claude/skills/review-squash-message/tokens.json
+++ b/.claude/skills/review-squash-message/tokens.json
@@ -12,10 +12,10 @@
   "bundled_files_tokens": 2164,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 2275,
-    "bytes": 7750,
+    "body_tokens": 2468,
+    "bytes": 8423,
     "frontmatter_tokens": 193,
-    "tokens": 2472
+    "tokens": 2665
   },
   "model": "claude-opus-5",
   "skill": "review-squash-message"

--- a/.claude/skills/write-pr-description/SKILL.md
+++ b/.claude/skills/write-pr-description/SKILL.md
@@ -66,7 +66,19 @@ Avoid:
 
 Where a draft already exists, the context printed it earlier. Keep the sentences that still hold. A revision that rewrites untouched prose costs the caller another review round for nothing, and it loses wording an earlier review already cleared.
 
+A finding names one instance of a fault rather than the fault itself. Fix the instance, then read the rest of the draft for the same fault, because a reviewer that found one instance finds the next one on the next round. That sweep isn't the rewriting this section warns against, since it changes a sentence only where the sentence is wrong.
+
 Where the published description differs from the draft, the branch has moved since the last publish. Bring the draft forward rather than reverting it to what GitHub shows.
+
+## Read the draft back before returning
+
+The validator covers what a script can check. What follows is what the reviewer sends drafts back for, and the context printed earlier already holds the answer to each, so a round trip spent on one buys nothing.
+
+**Closed enumerations.** A sentence naming the kinds of change on the branch claims to name every one, and a reviewer reads it that way. Walk the changed-file listing against every sentence of that shape, and confirm the sentence covers each path or that you left the path out on purpose. Where you can't confirm it, write the sentence open, so it claims only what you checked.
+
+**Scope words.** `only`, `every`, `never`, and `the one place` each make a claim about the files you didn't quote. Open the file and establish the scope before writing one. A setting described as mattering on a single CI slot is a claim about every other slot, and the workflow in the diff either bears that out or doesn't.
+
+**The Avoid list earlier in this document.** Read the finished draft against it once. Following a rule while writing and satisfying it in the finished text are different things.
 
 ## Clear the validator before returning
 

--- a/.claude/skills/write-pr-description/tokens.json
+++ b/.claude/skills/write-pr-description/tokens.json
@@ -17,10 +17,10 @@
   "bundled_files_tokens": 3593,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 1267,
-    "bytes": 4485,
+    "body_tokens": 1709,
+    "bytes": 5965,
     "frontmatter_tokens": 192,
-    "tokens": 1463
+    "tokens": 1905
   },
   "model": "claude-opus-5",
   "skill": "write-pr-description"

--- a/.config/mise/conf.d/10-repotools-tools.toml
+++ b/.config/mise/conf.d/10-repotools-tools.toml
@@ -59,11 +59,6 @@ gitleaks = "8.30.1"
 # directive's version whenever this pin trails it.
 go = "1.26.5"
 golangci-lint = "2.12.2"
-# Still needed by a consumer that has not retired its own Justfile.
-# repotools has none, so nothing here calls just; the pin and the
-# lint-just and format-just tasks stay until the last consumer drops
-# theirs.
-just = "1.57.0"
 # cspell ships only as an npm package. Homebrew was installing node too --
 # its formula's shebang already pointed at one. The difference is that
 # this node is pinned and locked.

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -116,20 +116,6 @@ url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golan
 url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
 provenance = "github-attestations"
 
-[[tools.just]]
-version = "1.57.0"
-backend = "aqua:casey/just"
-
-[tools.just."platforms.linux-x64"]
-checksum = "sha256:45b548094283cb9739af8f13273b8cddeee869f5b4ef2bb631b1f311cb566155"
-url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/casey/just/releases/assets/481976790"
-
-[tools.just."platforms.macos-arm64"]
-checksum = "sha256:0381db216c2f97ce31d838a1562c1064dfbfa73f5a8a81581338a2cd9217df47"
-url = "https://github.com/casey/just/releases/download/1.57.0/just-1.57.0-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/casey/just/releases/assets/481976803"
-
 [[tools.node]]
 version = "24.18.1"
 backend = "core:node"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
   // trailing comment is the only human-readable version at this site,
   // and `mise run repotools:check-pins` reads it.
   extends: [
-    "github>tbhb/repotools//.github/renovate-config.json5#01bd1c6e2c0bed9bf75285728669b48b6bcce9be", // v0.6.0
+    "github>tbhb/repotools//.github/renovate-config.json5#084187fbf70c30224bce9e7e20be69698f3a3cae", // v0.7.0
   ],
 
   // Single-repo scope. Differs per repo.

--- a/.github/workflows/lint-codeowners.yml
+++ b/.github/workflows/lint-codeowners.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@01bd1c6e2c0bed9bf75285728669b48b6bcce9be # v0.6.0
+    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@01bd1c6e2c0bed9bf75285728669b48b6bcce9be # v0.6.0
+    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -24,6 +24,6 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@01bd1c6e2c0bed9bf75285728669b48b6bcce9be # v0.6.0
+    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
     with:
       config_path: .github/renovate.json5

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate.yaml@01bd1c6e2c0bed9bf75285728669b48b6bcce9be # v0.6.0
+    uses: tbhb/repotools/.github/workflows/renovate.yaml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
     with:
       renovate_log_level_debug: ${{ inputs.renovate_log_level_debug || false }}
     secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   # SHA with a `# frozen:` tag comment so Renovate's pre-commit manager
   # tracks it.
   - repo: https://github.com/tbhb/repotools
-    rev: 01bd1c6e2c0bed9bf75285728669b48b6bcce9be  # frozen: v0.6.0
+    rev: 084187fbf70c30224bce9e7e20be69698f3a3cae  # frozen: v0.7.0
     hooks:
       - id: commit-trailers
       - id: commitlint

--- a/.repotools/tasks/format.toml
+++ b/.repotools/tasks/format.toml
@@ -34,11 +34,3 @@ run = "rumdl fmt $usage_paths"
 description = "Format JSON / JS / TS in place via biome"
 usage = 'arg "<paths>..." default="."'
 run = "biome format --write $usage_paths"
-
-# --fmt is still an unstable just feature; pass --unstable explicitly so
-# the task works regardless of the consumer Justfile's `set unstable`.
-# Takes no path args: --fmt only ever rewrites the justfile just
-# resolved for this invocation.
-["repotools:format-just"]
-description = "Format the Justfile in place with just's own formatter"
-run = "just --fmt --unstable"

--- a/.repotools/tasks/lint.toml
+++ b/.repotools/tasks/lint.toml
@@ -63,13 +63,6 @@ description = "Check spelling against the project dictionary (.cspell-words.txt)
 usage = 'arg "<paths>..." default="."'
 run = "cspell --config .cspell.jsonc --no-summary --no-progress --no-must-find-files --exclude COMMIT_AGENTMSG --exclude PR_AGENTDESC.md --exclude SQUASH_AGENTMSG $usage_paths"
 
-# Format-check the Justfile with just's own formatter. --check reports
-# the difference and exits non-zero without touching the file;
-# repotools:format-just is the in-place fixer.
-["repotools:lint-just"]
-description = "Format-check the Justfile with just's own formatter"
-run = "just --fmt --check --unstable"
-
 # actionlint walks `.github/workflows/` by default, parses each
 # workflow, and flags unknown actions, mis-typed expressions, shellcheck
 # issues inside `run:` blocks, and SHA-pin drift. Complements the

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-08-04T12:50:43.166790+00:00'
+generated_at: '2026-08-04T17:06:03.914997+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: tbhb/repotools
   name: repotools
   host: github.com
-  resolved_commit: 01bd1c6e2c0bed9bf75285728669b48b6bcce9be
-  resolved_ref: v0.6.0
-  version: 0.6.0
+  resolved_commit: 084187fbf70c30224bce9e7e20be69698f3a3cae
+  resolved_ref: v0.7.0
+  version: 0.7.0
   package_type: apm_package
   deployed_files:
   - .claude/rules/worktree-wip.md
@@ -138,22 +138,22 @@ dependencies:
     .claude/skills/fix-prose/scripts/preflight.sh: sha256:de4ce16740adec37b29bceeb0e5adbf021dbabeedcd9c7efc63179be479658cc
     .claude/skills/fix-prose/scripts/release-once.sh: sha256:3f7935af5f97859066f49eccb2c9ce68322e419e6fa06a047f54442ab06e8912
     .claude/skills/fix-prose/tokens.json: sha256:1d9c9a43c67cd336a626b5af57441fc3a55bef12fe74fbf8ab4b7ea20a77435b
-    .claude/skills/merge-pr/SKILL.md: sha256:24ea812e6cc01663fe4d9cc50dd93e902110471eb8e491e57138a9049577dbde
+    .claude/skills/merge-pr/SKILL.md: sha256:418582c9578c4a11e1a224fb4765871c691111de8de29ac82e27821638f14bab
     .claude/skills/merge-pr/scripts/guard-merge.sh: sha256:4b8d3377751cf151d8a8bf3e6b79715e172bdea4742217b9653562c310b216ca
     .claude/skills/merge-pr/scripts/populate-description.sh: sha256:ed9688d83433ff7e1700255ae02e3dc912faf34dc34bdd9edb22eb02b8032d3a
     .claude/skills/merge-pr/scripts/preflight.sh: sha256:164ee9756773d7c65c8da430309c42c2dd7b0553616d361c0bd7962c05d0f3d9
     .claude/skills/merge-pr/scripts/squash-merge.sh: sha256:4ad8fcd535fbc37524cf89baa42632eb40c156c23d0dfff47d22b9aa9caa930a
     .claude/skills/merge-pr/scripts/squash-message.sh: sha256:eeaca25d0bce0dc874ad389854e2bd4de77669cfed3da97c9999513652b7011a
     .claude/skills/merge-pr/scripts/stamp-review.sh: sha256:b54430e9cacb8045163dbc35c73be61de8f69fa236e1b41620fe1b10d0eaca0e
-    .claude/skills/merge-pr/tokens.json: sha256:81dd1cdb6a049853b2fd8021c99b248d48508aba16a73f777330ab959d77eb9d
-    .claude/skills/pr/SKILL.md: sha256:8c43be0176d721f78099de79c9acc68b7ae54ed1af83f807a47fdb568f42af28
+    .claude/skills/merge-pr/tokens.json: sha256:9e9ea0add42c635cd2ca21509b041346e816d94296feb46da3903515c06daa40
+    .claude/skills/pr/SKILL.md: sha256:5fc5c6e46c7c9c8c6ef6d9fd0c850f10104558127a0c41d97a88e332e13fbca0
     .claude/skills/pr/scripts/create-pr.sh: sha256:e4aba4ec72fcc682d6d362c590269358ad295300917a0c25d106d290f3cd7b82
     .claude/skills/pr/scripts/guard-gh.sh: sha256:48849363413f51369df0eabce051afc97109033a8ad50666e685b1160b4f624a
     .claude/skills/pr/scripts/preflight.sh: sha256:eabf109e3c6e24ff0185dfb6d6f90bc95bd5bb44c8642887c9e8b0085c089829
     .claude/skills/pr/scripts/scaffold-description.sh: sha256:e8a7e913e21a56f29851e614033dcbff888cc7863e70446f2ce8dfc3fe77dedb
     .claude/skills/pr/scripts/stamp-review.sh: sha256:0836faf6bbb81ef45d612034e6fb67f2de9475a499aac1d5f44f2507c803a953
     .claude/skills/pr/scripts/validate-description.sh: sha256:06798be90499be5695209f93076bc8bf6ce1fb4c8145dbd3f85c951488be2575
-    .claude/skills/pr/tokens.json: sha256:58f227faabe9edbdce1993f2616ca669f21cd5bf7fb274d8852624dd50aedff1
+    .claude/skills/pr/tokens.json: sha256:b35dfd96352ffed27d73e91642d003cb270782131a20cc427fe93b1af57c9c74
     .claude/skills/rebase/SKILL.md: sha256:35c39badb3c67e9ddbebbb485b278833afb74548e1421e1ea7a602ad8f350dc1
     .claude/skills/rebase/scripts/continue-rebase.sh: sha256:0cb326c120efab5b50969b29e21dacb08d655264b80ccd43ef9b7db7ae7b26db
     .claude/skills/rebase/scripts/guard-rebase.sh: sha256:dafe9b3b12a713dc14a32ce48ad1baf93be9bcba62f04e815e57667a746e1efd
@@ -172,25 +172,25 @@ dependencies:
     .claude/skills/resolve-rebase-conflicts/tokens.json: sha256:9911ba26395219bc9694cacf1645f38dbfd785f4caba2ae4d45dd177ce999f6d
     .claude/skills/review-commit-message/SKILL.md: sha256:5a02ff2ee3419a12dc71b2e298ee97f9d02928e51f92eb769a75762a5866414c
     .claude/skills/review-commit-message/tokens.json: sha256:97d50df77eb89bbba01e7c17408ba6fd228ad036d6c27537660c566d3e77fa05
-    .claude/skills/review-pr-description/SKILL.md: sha256:b73e53c7011fbd9f16d922b2fe7482bbc2ba13628c8d53d9f897625a202aaeb7
-    .claude/skills/review-pr-description/tokens.json: sha256:44eb0e93c0e155142f79b8101fab86ac6cba62c6d451fc9ac68006d8f955f9c2
-    .claude/skills/review-prose-fix/SKILL.md: sha256:c17f0f5944d4ee09c6c3e89b5833d7dc92686ea31657b1908ef4174841f01abf
-    .claude/skills/review-prose-fix/tokens.json: sha256:b8fa2bd099d312f303730dacaa5380cb320ebdc23080873db6cbb5c76c4567f0
-    .claude/skills/review-squash-message/SKILL.md: sha256:e7881d15801e73001a3d10138af9c7807d1ba95384547890bcf6ea092e289177
+    .claude/skills/review-pr-description/SKILL.md: sha256:150aa2fcce0043f8704683b982c026cc569844c41543a774f498f4b07a6dd528
+    .claude/skills/review-pr-description/tokens.json: sha256:9fdf3d0de53316a2e33f1b40a775d95cc8281877dc255e6cf597f991f75e03ff
+    .claude/skills/review-prose-fix/SKILL.md: sha256:5061db9a99d1833b565047f7888e3c889c5608baf9bb33e0b27ada936d6e7c8a
+    .claude/skills/review-prose-fix/tokens.json: sha256:a8199b47458d65d5964a27d0f7cc96e61a0ff45f0dd10344abb21a0c92904e58
+    .claude/skills/review-squash-message/SKILL.md: sha256:ab2bc599f50e01a4bdffa7963fac4e44aa951aff32f741db6be79f447c3d078b
     .claude/skills/review-squash-message/scripts/context.sh: sha256:c8feff629fee467eaf0240582f0a30eb54c3b12ee97e5ba205859dabb6951b3c
-    .claude/skills/review-squash-message/tokens.json: sha256:daf6342240404c89af42a55b33285e7083af9fd41a7623da6a48083fa961e162
+    .claude/skills/review-squash-message/tokens.json: sha256:76a94eedf22a4ea1fe8e1ff7a4ed3b8752c851206a9fc117959ec911a2b03a57
     .claude/skills/watch-pr/SKILL.md: sha256:174ed7841d50ff09d8b63c7e816f55ce5328a1bd17e267d9a86c652e48f484cb
     .claude/skills/watch-pr/scripts/guard-watch.sh: sha256:6fc489a3c60f9b669fa9290d871532ddf0dbae056f4ce50a7335238030fccba8
     .claude/skills/watch-pr/scripts/watch-checks.sh: sha256:341a13a8e9ddf14f3adadfc2c905ee848357c61a0375bd539edea6710bb49c76
     .claude/skills/watch-pr/tokens.json: sha256:21d22a1b5afa9e556004a59b98490300a63bbf16aa86f0f5af82255f509e58dc
-    .claude/skills/write-pr-description/SKILL.md: sha256:72c12902b1d9c3032ec4cf42f51f618498f95352c507cfc4a4e5b9788f19301d
+    .claude/skills/write-pr-description/SKILL.md: sha256:46c50e61d1b84840d9a919873775b49d93f91a1ca92935f1cc21449fa0d4c341
     .claude/skills/write-pr-description/scripts/context.sh: sha256:8f2963be66de209a31573696847645f7252028a5648ed2b0f97a71cc39ff72d6
     .claude/skills/write-pr-description/scripts/guard-draft.sh: sha256:8c0a80c080fa29e231745de949d5821f273f062fc6ae0ed78b6cc4167da8d443
-    .claude/skills/write-pr-description/tokens.json: sha256:a1c681ef0391dc19736f8c01098b852769bd896c5782dbc9c819aa0b01abf9ff
+    .claude/skills/write-pr-description/tokens.json: sha256:ff57cfb6f0d6712010c990b77eb0801727541e8287508ca26453749037d565f6
     .claude/skills/write-prose-fix/SKILL.md: sha256:9b7f0e2c333189ff9ae76d0c084590139120f6a05963c84015eb609cad00bd0b
     .claude/skills/write-prose-fix/scripts/context.sh: sha256:a8f111896e3a438307b1c7467724f8ad43ee25c0234fae7b0939e256ae333aca
     .claude/skills/write-prose-fix/tokens.json: sha256:5e02b07de31ed9fd232c920628a87ba570cb76b7543c43505de645828b31c1dc
-  content_hash: sha256:14349895049ee1d0de35af3557458c4559214af29c78025da0dd0697acdac2c1
+  content_hash: sha256:c5851ea5518ca896e4d6a59e8c8591770993918c96b80a14feda7bec389cc01c
   declared_license: Apache-2.0
 deployments:
 - kind: project-relative
@@ -516,7 +516,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:24ea812e6cc01663fe4d9cc50dd93e902110471eb8e491e57138a9049577dbde
+  content_hash: sha256:418582c9578c4a11e1a224fb4765871c691111de8de29ac82e27821638f14bab
 - kind: project-relative
   target: claude
   value: .claude/skills/merge-pr/scripts/guard-merge.sh
@@ -579,7 +579,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:81dd1cdb6a049853b2fd8021c99b248d48508aba16a73f777330ab959d77eb9d
+  content_hash: sha256:9e9ea0add42c635cd2ca21509b041346e816d94296feb46da3903515c06daa40
 - kind: project-relative
   target: claude
   value: .claude/skills/pr
@@ -597,7 +597,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:8c43be0176d721f78099de79c9acc68b7ae54ed1af83f807a47fdb568f42af28
+  content_hash: sha256:5fc5c6e46c7c9c8c6ef6d9fd0c850f10104558127a0c41d97a88e332e13fbca0
 - kind: project-relative
   target: claude
   value: .claude/skills/pr/scripts/create-pr.sh
@@ -660,7 +660,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:58f227faabe9edbdce1993f2616ca669f21cd5bf7fb274d8852624dd50aedff1
+  content_hash: sha256:b35dfd96352ffed27d73e91642d003cb270782131a20cc427fe93b1af57c9c74
 - kind: project-relative
   target: claude
   value: .claude/skills/rebase
@@ -867,7 +867,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:b73e53c7011fbd9f16d922b2fe7482bbc2ba13628c8d53d9f897625a202aaeb7
+  content_hash: sha256:150aa2fcce0043f8704683b982c026cc569844c41543a774f498f4b07a6dd528
 - kind: project-relative
   target: claude
   value: .claude/skills/review-pr-description/tokens.json
@@ -876,7 +876,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:44eb0e93c0e155142f79b8101fab86ac6cba62c6d451fc9ac68006d8f955f9c2
+  content_hash: sha256:9fdf3d0de53316a2e33f1b40a775d95cc8281877dc255e6cf597f991f75e03ff
 - kind: project-relative
   target: claude
   value: .claude/skills/review-prose-fix
@@ -894,7 +894,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:c17f0f5944d4ee09c6c3e89b5833d7dc92686ea31657b1908ef4174841f01abf
+  content_hash: sha256:5061db9a99d1833b565047f7888e3c889c5608baf9bb33e0b27ada936d6e7c8a
 - kind: project-relative
   target: claude
   value: .claude/skills/review-prose-fix/tokens.json
@@ -903,7 +903,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:b8fa2bd099d312f303730dacaa5380cb320ebdc23080873db6cbb5c76c4567f0
+  content_hash: sha256:a8199b47458d65d5964a27d0f7cc96e61a0ff45f0dd10344abb21a0c92904e58
 - kind: project-relative
   target: claude
   value: .claude/skills/review-squash-message
@@ -921,7 +921,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:e7881d15801e73001a3d10138af9c7807d1ba95384547890bcf6ea092e289177
+  content_hash: sha256:ab2bc599f50e01a4bdffa7963fac4e44aa951aff32f741db6be79f447c3d078b
 - kind: project-relative
   target: claude
   value: .claude/skills/review-squash-message/scripts/context.sh
@@ -939,7 +939,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:daf6342240404c89af42a55b33285e7083af9fd41a7623da6a48083fa961e162
+  content_hash: sha256:76a94eedf22a4ea1fe8e1ff7a4ed3b8752c851206a9fc117959ec911a2b03a57
 - kind: project-relative
   target: claude
   value: .claude/skills/watch-pr
@@ -1002,7 +1002,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:72c12902b1d9c3032ec4cf42f51f618498f95352c507cfc4a4e5b9788f19301d
+  content_hash: sha256:46c50e61d1b84840d9a919873775b49d93f91a1ca92935f1cc21449fa0d4c341
 - kind: project-relative
   target: claude
   value: .claude/skills/write-pr-description/scripts/context.sh
@@ -1029,7 +1029,7 @@ deployments:
   owners:
   - tbhb/repotools
   active_owner: tbhb/repotools
-  content_hash: sha256:a1c681ef0391dc19736f8c01098b852769bd896c5782dbc9c819aa0b01abf9ff
+  content_hash: sha256:ff57cfb6f0d6712010c990b77eb0801727541e8287508ca26453749037d565f6
 - kind: project-relative
   target: claude
   value: .claude/skills/write-prose-fix

--- a/apm.yml
+++ b/apm.yml
@@ -12,5 +12,5 @@ target:
   - claude
 dependencies:
   apm:
-    - tbhb/repotools#v0.6.0
+    - tbhb/repotools#v0.7.0
   mcp: []

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,18 +2,18 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.6.0 [skip ci]'
-      sha: 01bd1c6e2c0bed9bf75285728669b48b6bcce9be
+      commitTitle: 'chore(version): v0.7.0 [skip ci]'
+      sha: 084187fbf70c30224bce9e7e20be69698f3a3cae
       tags:
-      - v0.6.0
+      - v0.7.0
     path: .
   path: .config/mise/conf.d
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.6.0 [skip ci]'
-      sha: 01bd1c6e2c0bed9bf75285728669b48b6bcce9be
+      commitTitle: 'chore(version): v0.7.0 [skip ci]'
+      sha: 084187fbf70c30224bce9e7e20be69698f3a3cae
       tags:
-      - v0.6.0
+      - v0.7.0
     path: .
   path: .repotools
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.6.0
+          ref: v0.7.0
         includePaths:
           - .config/mise/conf.d/**
         newRootPath: .config/mise/conf.d
@@ -31,7 +31,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.6.0
+          ref: v0.7.0
         includePaths:
           - .repotools/**
         newRootPath: .repotools


### PR DESCRIPTION
## Summary

Moves the `tbhb/repotools` pin from v0.6.0 to v0.7.0 everywhere it appears: `apm.yml`, `vendir.yml`, `.pre-commit-config.yaml`, the workflow `uses` lines under `.github/workflows/`, and the `renovate.json5` preset extends. The vendored payload under `.config/mise/conf.d/` and `.repotools/` resynchronized to match, the `apm.lock.yaml` and `vendir.lock.yml` lockfiles regenerated, and the apm-managed skill files under `.claude/skills/` redeployed with the content v0.7.0 now pins.

## Why

v0.7.0 is the release where `repotools` drops the shared `just` pin: `repotools` has carried no Justfile of its own since v0.5.0, and this repository dropped its last Justfile when it adopted v0.6.0, so the pin and its `repotools:lint-just`/`repotools:format-just` tasks finally have no consumer left standing on them. That removal reaches this repository only once the pin here moves, since both the pin and the tasks lived in the vendored payload rather than in this repository's own files.

The pin move also redeploys the apm-managed skills that provide review instructions: `review-pr-description`, `review-prose-fix`, and `review-squash-message` each gain an instruction to sweep a draft for repeated instances of a finding before writing their verdict, rather than returning one instance per round. `pr`, `merge-pr`, and `write-pr-description` gain matching updates: `pr` now separates rounds a finding caused from rounds the branch caused when bounding its review loop, `merge-pr` picks up the same one-instance-names-a-fault framing for squash-message findings, and `write-pr-description` gains a pre-return checklist that catches closed-enumeration and scope-word errors before a reviewer has to.

## Verification

- `mise run repotools:check-pins`. Every pin site reports v0.7.0.
- `mise run repotools:check-vendored`. The vendored payload matches what git holds.
- `mise run lint`. Every linter in the gate, including `repotools:lint-mise` and `repotools:lint-toml`, passes.
- `mise run test`. The fixture guard (tell corpus, commit-message smoke test, false-positive check) passes.

## Risk

If v0.7.0 turns out to carry a defect, the fix is reverting this commit, which restores every pin site to v0.6.0, restores the `just` tool pin and the `repotools:lint-just`/`repotools:format-just` tasks it backed, and restores the pre-v0.7.0 skill files. Nothing in this branch depends on the new sweep behavior in the review skills, so the only functional exposure is the loss of the just tasks, which nothing here still calls.

## Related

None.
