### PR TITLE
build(deps): move every `repotools` pin to v0.7.1

### DIFF
--- a/.config/mise/conf.d/10-repotools-tools.toml
+++ b/.config/mise/conf.d/10-repotools-tools.toml
@@ -52,7 +52,7 @@ gitleaks = "8.30.1"
 # module root, no cmd/ suffix, so Renovate's built-in mise manager
 # resolves this pin through the go datasource without the custom
 # suffix-stripping manager.
-"go:github.com/fe3dback/go-arch-lint" = "v1.15.0"
+"go:github.com/fe3dback/go-arch-lint" = "v1.17.0"
 # Required by the go: backends above, which compile rather than
 # download. Matches the go.mod toolchain directive; go.mod stays the
 # authority for module builds, because GOTOOLCHAIN=auto fetches the
@@ -62,8 +62,8 @@ golangci-lint = "2.12.2"
 # cspell ships only as an npm package. Homebrew was installing node too --
 # its formula's shebang already pointed at one. The difference is that
 # this node is pinned and locked.
-node = "24.18.1"
-prek = "0.4.11"
+node = "24.19.0"
+prek = "0.4.13"
 rumdl = "0.2.48"
 # The YAML gate, replacing yamllint and the last Python-implemented
 # linter that checks non-Python files. ryl reimplements all 23 yamllint
@@ -75,5 +75,5 @@ rumdl = "0.2.48"
 # derives the crate datasource from the backend.
 "cargo:ryl" = "0.21.0"
 shellcheck = "0.11.0"
-tombi = "1.2.5"
+tombi = "1.2.10"
 vale = "3.17.0"

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -97,7 +97,7 @@ version = "3.9.0"
 backend = "go:github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker"
 
 [[tools."go:github.com/fe3dback/go-arch-lint"]]
-version = "1.15.0"
+version = "1.17.0"
 backend = "go:github.com/fe3dback/go-arch-lint"
 
 [[tools.golangci-lint]]
@@ -117,31 +117,31 @@ url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/4
 provenance = "github-attestations"
 
 [[tools.node]]
-version = "24.18.1"
+version = "24.19.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:9f5eb6ac21845a66c493c91a253b1da32fd684e89e9b7202d4936982336be4ca"
-url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-x64.tar.gz"
+checksum = "sha256:f625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-x64.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:eb02f7fab96d3d67de40c5ec8566096fcb4c2026728787683ae5a97eb612b941"
-url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-darwin-arm64.tar.gz"
+checksum = "sha256:8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz"
 
 [[tools.prek]]
-version = "0.4.11"
+version = "0.4.13"
 backend = "aqua:j178/prek"
 
 [tools.prek."platforms.linux-x64"]
-checksum = "sha256:fadf7f14fb570cb38051e8651cfe3b3b11ea499207a245c2aff09585cccb776a"
-url = "https://github.com/j178/prek/releases/download/v0.4.11/prek-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/j178/prek/releases/assets/488626498"
+checksum = "sha256:15dbf93535fc956a09e0e13e0529f364aff94c9d048f36a41571bb802e096ec0"
+url = "https://github.com/j178/prek/releases/download/v0.4.13/prek-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/508529829"
 provenance = "github-attestations"
 
 [tools.prek."platforms.macos-arm64"]
-checksum = "sha256:92f8133ba6ff1c16066d9af521f7a72db6235becc845021363238fa8539c1132"
-url = "https://github.com/j178/prek/releases/download/v0.4.11/prek-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/j178/prek/releases/assets/488626436"
+checksum = "sha256:776da7aa143b3cb11125f9c6f44ab5af157c176c992b7bfbafc1b155a44ac769"
+url = "https://github.com/j178/prek/releases/download/v0.4.13/prek-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/508529745"
 provenance = "github-attestations"
 
 [[tools.rumdl]]
@@ -175,19 +175,19 @@ url = "https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellche
 url_api = "https://api.github.com/repos/koalaman/shellcheck/releases/assets/279056932"
 
 [[tools.tombi]]
-version = "1.2.5"
+version = "1.2.10"
 backend = "aqua:tombi-toml/tombi"
 
 [tools.tombi."platforms.linux-x64"]
-checksum = "sha256:05385bdf47d10828c1fc27190ee0ad44b777a57f56ea95c9ef568c845e3b7872"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.5/tombi-cli-1.2.5-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/496096100"
+checksum = "sha256:abb3bc596699020506d7dccde7ea5f884970a2baabd4afab9cc513c1b75cb774"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637503"
 provenance = "github-attestations"
 
 [tools.tombi."platforms.macos-arm64"]
-checksum = "sha256:e4c3dd5346650b80afa516b851e0bffb4ea8a8b51ced974712fd0dd10cb893ee"
-url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.5/tombi-cli-1.2.5-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/496096095"
+checksum = "sha256:153adcddaa70c53358c08287ffa20697926c149f8413d700b9961793891561a7"
+url = "https://github.com/tombi-toml/tombi/releases/download/v1.2.10/tombi-cli-1.2.10-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/tombi-toml/tombi/releases/assets/508637483"
 provenance = "github-attestations"
 
 [[tools.vale]]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
   // trailing comment is the only human-readable version at this site,
   // and `mise run repotools:check-pins` reads it.
   extends: [
-    "github>tbhb/repotools//.github/renovate-config.json5#084187fbf70c30224bce9e7e20be69698f3a3cae", // v0.7.0
+    "github>tbhb/repotools//.github/renovate-config.json5#9c1ec57c7ca45a9faf8054289fa07e80700fac2d", // v0.7.1
   ],
 
   // Single-repo scope. Differs per repo.

--- a/.github/workflows/lint-codeowners.yml
+++ b/.github/workflows/lint-codeowners.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
+    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
+    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -24,6 +24,6 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
+    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
     with:
       config_path: .github/renovate.json5

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate.yaml@084187fbf70c30224bce9e7e20be69698f3a3cae # v0.7.0
+    uses: tbhb/repotools/.github/workflows/renovate.yaml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
     with:
       renovate_log_level_debug: ${{ inputs.renovate_log_level_debug || false }}
     secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   # SHA with a `# frozen:` tag comment so Renovate's pre-commit manager
   # tracks it.
   - repo: https://github.com/tbhb/repotools
-    rev: 084187fbf70c30224bce9e7e20be69698f3a3cae  # frozen: v0.7.0
+    rev: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d  # frozen: v0.7.1
     hooks:
       - id: commit-trailers
       - id: commitlint

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,13 @@
 lockfile_version: '1'
-generated_at: '2026-08-04T17:06:03.914997+00:00'
+generated_at: '2026-08-15T19:03:30.128382+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: tbhb/repotools
   name: repotools
   host: github.com
-  resolved_commit: 084187fbf70c30224bce9e7e20be69698f3a3cae
-  resolved_ref: v0.7.0
-  version: 0.7.0
+  resolved_commit: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
+  resolved_ref: v0.7.1
+  version: 0.7.1
   package_type: apm_package
   deployed_files:
   - .claude/rules/worktree-wip.md
@@ -190,7 +190,7 @@ dependencies:
     .claude/skills/write-prose-fix/SKILL.md: sha256:9b7f0e2c333189ff9ae76d0c084590139120f6a05963c84015eb609cad00bd0b
     .claude/skills/write-prose-fix/scripts/context.sh: sha256:a8f111896e3a438307b1c7467724f8ad43ee25c0234fae7b0939e256ae333aca
     .claude/skills/write-prose-fix/tokens.json: sha256:5e02b07de31ed9fd232c920628a87ba570cb76b7543c43505de645828b31c1dc
-  content_hash: sha256:c5851ea5518ca896e4d6a59e8c8591770993918c96b80a14feda7bec389cc01c
+  content_hash: sha256:dcbfad3e0aad74a32d86b3a6d178c0e6307f6f48fca8bb47746d05bd606867c9
   declared_license: Apache-2.0
 deployments:
 - kind: project-relative

--- a/apm.yml
+++ b/apm.yml
@@ -12,5 +12,5 @@ target:
   - claude
 dependencies:
   apm:
-    - tbhb/repotools#v0.7.0
+    - tbhb/repotools#v0.7.1
   mcp: []

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,18 +2,18 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.7.0 [skip ci]'
-      sha: 084187fbf70c30224bce9e7e20be69698f3a3cae
+      commitTitle: 'chore(version): v0.7.1 [skip ci]'
+      sha: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
       tags:
-      - v0.7.0
+      - v0.7.1
     path: .
   path: .config/mise/conf.d
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.7.0 [skip ci]'
-      sha: 084187fbf70c30224bce9e7e20be69698f3a3cae
+      commitTitle: 'chore(version): v0.7.1 [skip ci]'
+      sha: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
       tags:
-      - v0.7.0
+      - v0.7.1
     path: .
   path: .repotools
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.7.0
+          ref: v0.7.1
         includePaths:
           - .config/mise/conf.d/**
         newRootPath: .config/mise/conf.d
@@ -31,7 +31,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.7.0
+          ref: v0.7.1
         includePaths:
           - .repotools/**
         newRootPath: .repotools


### PR DESCRIPTION
## Summary

Every `repotools` pin site in this repository moves to v0.7.1, the vendored payload updates to that tag, and the `apm`, `vendir`, and `mise` lockfiles follow.

## Why

The built-in mise manager in Renovate read the vendored tool pins under `.config/mise/conf.d` as ordinary pins and opened pull requests editing them in place. `vendir` owns that directory and `.repotools` outright and deletes anything the vendored ref does not carry, so `repotools:check-vendored` failed every one of those pull requests and they closed without a merge.

In v0.7.1, the shared preset turns Renovate off on both paths in every repository except `repotools` itself, where those are the original files rather than a vendored copy. Moving the `extends` pin in `.github/renovate.json5` puts this repository under the corrected preset, so the manager stops proposing an edit no consumer may keep.

Updating the payload to that tag brings in the `go-arch-lint`, `node`, `prek`, and `tombi` versions those closed pull requests wanted, this time through the vendored ref rather than around it. The `rumdl` bump they also proposed is not in this ref. It arrives whenever `repotools` takes it.

## Verification

`mise run repotools:check-vendored` reports the payload matching what git holds, and `mise run repotools:check-pins` reports every pin site on v0.7.1. `mise run test` passes the fixture guard. The gates under `mise run lint` pass, except that its markdown, spelling, and prose checks report findings falling entirely in working-tree documents this branch does not add and git does not track.

## Risk

If the exclusion in the preset does not hold, Renovate resumes editing the vendored directories and `repotools:check-vendored` fails those pull requests the same way it did before, which is noisy rather than damaging. Reverting the commit puts every pin site and the payload back on v0.7.0.

## Related

The Renovate pull requests that closed without a merge against the vendored paths: #17, #18, #19, #21, #22. The preceding pin move is #16.
