### PR TITLE
build(deps): move every `repotools` pin to v0.8.0

### DIFF
--- a/.claude/apm-hooks.json
+++ b/.claude/apm-hooks.json
@@ -9,7 +9,7 @@
           "timeout": 10
         }
       ],
-      "_apm_source": "repotools"
+      "_apm_source": "claude"
     }
   ]
 }

--- a/.claude/skills/analyze-session/SKILL.md
+++ b/.claude/skills/analyze-session/SKILL.md
@@ -13,7 +13,7 @@ Work the steps in order. This skill ends once the retrospective exists on disk a
 
 `$ARGUMENTS` holds the absolute path to the transcript. A bare session ID also works, provided it names exactly one file under `~/.claude/projects/`.
 
-Given neither, the preflight says so and prints how to find it. Send a Haiku subagent, then run the preflight again with the path it returns. Never search the projects directory yourself. Reading transcripts to find one costs more context than the entire analysis that follows it.
+If you give neither, the preflight says so and prints how to find it. Send a Haiku subagent, then run the preflight again with the path it returns. Never search the projects directory yourself. Reading transcripts to find one costs more context than the entire analysis that follows it.
 
 ## Preflight
 

--- a/.claude/skills/analyze-session/references/VERIFY_FIGURES.md
+++ b/.claude/skills/analyze-session/references/VERIFY_FIGURES.md
@@ -67,7 +67,7 @@ A verifier that hasn't answered yet isn't an abstention, and counting it as one 
 ## Consensus
 
 - Where all three replicate a figure, it stands.
-- Where one dissents, report the figure and name the reading that differed.
+- Where one dissents, report the figure, and name the reading that differed.
 - Where two dissent, something is wrong with the figure or ambiguous about the command. Re-derive it, or drop the claim.
 
 Check whether a verifier that agrees with everything actually ran the commands. Replication means running them again, so a verdict without a command behind it proves nothing.

--- a/.claude/skills/analyze-session/tokens.json
+++ b/.claude/skills/analyze-session/tokens.json
@@ -19,9 +19,9 @@
       "tokens": 1251
     },
     {
-      "bytes": 3467,
+      "bytes": 3468,
       "path": "references/VERIFY_FIGURES.md",
-      "tokens": 1173
+      "tokens": 1174
     },
     {
       "bytes": 3205,
@@ -49,13 +49,13 @@
       "tokens": 959
     }
   ],
-  "bundled_files_tokens": 17749,
+  "bundled_files_tokens": 17750,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 1674,
-    "bytes": 5532,
+    "body_tokens": 1675,
+    "bytes": 5538,
     "frontmatter_tokens": 126,
-    "tokens": 1804
+    "tokens": 1805
   },
   "model": "claude-opus-5",
   "skill": "analyze-session"

--- a/.claude/skills/review-pr-description/SKILL.md
+++ b/.claude/skills/review-pr-description/SKILL.md
@@ -83,7 +83,7 @@ The description covers the whole branch, not the commit its author happened to w
 
 Judge the branch, not the description.
 
-- Does the branch carry one change, one a reviewer can hold in their head, one that merges or reverts as a unit?
+- Does the branch carry one change that a reviewer can hold in their head and that merges or reverts as a unit?
 - Flag a branch mixing unrelated work, and name the pull requests it should split into. Reviewers miss things in a branch that changed three unrelated areas.
 - A change plus its tests, or a change plus the documentation describing it, counts as one change. Leave that alone.
 - Size alone isn't a finding. A wide mechanical rename counts as one change. A small diff touching two unrelated subsystems doesn't.

--- a/.claude/skills/review-pr-description/tokens.json
+++ b/.claude/skills/review-pr-description/tokens.json
@@ -6,10 +6,10 @@
   "bundled_files_tokens": 0,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 2131,
-    "bytes": 6966,
+    "body_tokens": 2129,
+    "bytes": 6965,
     "frontmatter_tokens": 172,
-    "tokens": 2307
+    "tokens": 2305
   },
   "model": "claude-opus-5",
   "skill": "review-pr-description"

--- a/.claude/skills/review-squash-message/SKILL.md
+++ b/.claude/skills/review-squash-message/SKILL.md
@@ -48,7 +48,7 @@ Work these four groups. Every finding names the exact offending text and the fix
 
 This group is why the review exists. Take the commits one at a time and ask whether someone reading the message alone would know that work is in here.
 
-- Flag a commit whose reason the message drops. Not its diff, its reason, meaning the constraint or the problem its body named. That sentence goes with the commit at the merge, and nothing else records it.
+- Flag a commit whose reason the message drops. Not its diff, its reason, meaning the constraint, or the problem its body named. That sentence goes with the commit at the merge, and nothing else records it.
 - Flag a message that describes one commit as though it were the branch. The last commit and the largest commit are the ones that stand in for the rest.
 - Flag a message that covers the early commits and stops. A branch that grew after someone published its description is the common case, and the message inherits the gap.
 - Flag two commits giving different reasons where the message keeps only one. Either it covers both, or it says which one subsumes the other.

--- a/.claude/skills/review-squash-message/tokens.json
+++ b/.claude/skills/review-squash-message/tokens.json
@@ -12,10 +12,10 @@
   "bundled_files_tokens": 2164,
   "generated_by": "tools/skill-tokens.sh",
   "manifest": {
-    "body_tokens": 2468,
-    "bytes": 8423,
+    "body_tokens": 2469,
+    "bytes": 8424,
     "frontmatter_tokens": 193,
-    "tokens": 2665
+    "tokens": 2666
   },
   "model": "claude-opus-5",
   "skill": "review-squash-message"

--- a/.config/mise/conf.d/10-repotools-tools.toml
+++ b/.config/mise/conf.d/10-repotools-tools.toml
@@ -64,7 +64,7 @@ golangci-lint = "2.12.2"
 # this node is pinned and locked.
 node = "24.19.0"
 prek = "0.4.13"
-rumdl = "0.2.48"
+rumdl = "v0.2.53"
 # The YAML gate, replacing yamllint and the last Python-implemented
 # linter that checks non-Python files. ryl reimplements all 23 yamllint
 # rules in Rust and reads the same .yamllint.yaml, so the config is

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -145,19 +145,19 @@ url_api = "https://api.github.com/repos/j178/prek/releases/assets/508529745"
 provenance = "github-attestations"
 
 [[tools.rumdl]]
-version = "0.2.48"
+version = "v0.2.53"
 backend = "aqua:rvben/rumdl"
 
 [tools.rumdl."platforms.linux-x64"]
-checksum = "sha256:d04ca4db4bbb971dec5218b44e6846c08f4cc0e2f191d38f9c4cf3ae6459602f"
-url = "https://github.com/rvben/rumdl/releases/download/v0.2.48/rumdl-v0.2.48-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/497748216"
+checksum = "sha256:5c85fc85f1fedf8f39ea7316b6fc090c2be112cc9d8997006e59e9ce2315aa11"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.53/rumdl-v0.2.53-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/508363440"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.macos-arm64"]
-checksum = "sha256:d98ef1933909b34413158b09dd7b682962b6376d115bafa5b204a13704e0c0f6"
-url = "https://github.com/rvben/rumdl/releases/download/v0.2.48/rumdl-v0.2.48-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/497748226"
+checksum = "sha256:bcda6474f0b625c9a6d11d6ff9ee627f1b7df5e61253fef708702c71a2394d68"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.53/rumdl-v0.2.53-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/508363449"
 provenance = "github-attestations"
 
 [[tools.shellcheck]]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,7 +25,7 @@
   // trailing comment is the only human-readable version at this site,
   // and `mise run repotools:check-pins` reads it.
   extends: [
-    "github>tbhb/repotools//.github/renovate-config.json5#9c1ec57c7ca45a9faf8054289fa07e80700fac2d", // v0.7.1
+    "github>tbhb/repotools//.github/renovate-config.json5#7afd9b223004dca83b415e7871ad63f2a9e1917f", // v0.8.0
   ],
 
   // Single-repo scope. Differs per repo.

--- a/.github/workflows/lint-codeowners.yml
+++ b/.github/workflows/lint-codeowners.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
+    uses: tbhb/repotools/.github/workflows/lint-codeowners.yml@7afd9b223004dca83b415e7871ad63f2a9e1917f # v0.8.0

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
+    uses: tbhb/repotools/.github/workflows/lint-workflows.yml@7afd9b223004dca83b415e7871ad63f2a9e1917f # v0.8.0

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -24,6 +24,6 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
+    uses: tbhb/repotools/.github/workflows/renovate-config-validator.yaml@7afd9b223004dca83b415e7871ad63f2a9e1917f # v0.8.0
     with:
       config_path: .github/renovate.json5

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,7 +36,7 @@ jobs:
     permissions:
       contents: read
     # yamllint disable-line rule:line-length
-    uses: tbhb/repotools/.github/workflows/renovate.yaml@9c1ec57c7ca45a9faf8054289fa07e80700fac2d # v0.7.1
+    uses: tbhb/repotools/.github/workflows/renovate.yaml@7afd9b223004dca83b415e7871ad63f2a9e1917f # v0.8.0
     with:
       renovate_log_level_debug: ${{ inputs.renovate_log_level_debug || false }}
     secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   # SHA with a `# frozen:` tag comment so Renovate's pre-commit manager
   # tracks it.
   - repo: https://github.com/tbhb/repotools
-    rev: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d  # frozen: v0.7.1
+    rev: 7afd9b223004dca83b415e7871ad63f2a9e1917f  # frozen: v0.8.0
     hooks:
       - id: commit-trailers
       - id: commitlint

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,16 +1,41 @@
 lockfile_version: '1'
-generated_at: '2026-08-15T19:03:30.128382+00:00'
+generated_at: '2026-08-16T01:55:26.159636+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: tbhb/repotools
   name: repotools
   host: github.com
-  resolved_commit: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
-  resolved_ref: v0.7.1
-  version: 0.7.1
+  resolved_commit: 7afd9b223004dca83b415e7871ad63f2a9e1917f
+  resolved_ref: v0.8.0
+  version: 0.8.0
+  package_type: apm_package
+  content_hash: sha256:a3fc45cf93b99b74c245b5132babce774b577999ff916e3e8ed9aea5b16b11de
+  declared_license: Apache-2.0
+- repo_url: tbhb/repotools
+  name: repotools-agents-agy
+  host: github.com
+  resolved_commit: 7afd9b223004dca83b415e7871ad63f2a9e1917f
+  resolved_ref: v0.8.0
+  version: 0.8.0
+  virtual_path: packages/agents/agy
+  is_virtual: true
+  depth: 2
+  resolved_by: tbhb/repotools
+  package_type: apm_package
+  content_hash: sha256:95031bd4ce99cc55532f0870d37330e7112a27c77f687d41ae0cb9595a8874ed
+  declared_license: Apache-2.0
+- repo_url: tbhb/repotools
+  name: repotools-agents-claude
+  host: github.com
+  resolved_commit: 7afd9b223004dca83b415e7871ad63f2a9e1917f
+  resolved_ref: v0.8.0
+  version: 0.8.0
+  virtual_path: packages/agents/claude
+  is_virtual: true
+  depth: 2
+  resolved_by: tbhb/repotools
   package_type: apm_package
   deployed_files:
-  - .claude/rules/worktree-wip.md
   - .claude/skills/analyze-session
   - .claude/skills/analyze-session/SKILL.md
   - .claude/skills/analyze-session/references/FIX_SURFACES.md
@@ -108,18 +133,17 @@ dependencies:
   - .claude/skills/write-prose-fix/scripts/context.sh
   - .claude/skills/write-prose-fix/tokens.json
   deployed_file_hashes:
-    .claude/rules/worktree-wip.md: sha256:0204082643d1ea505ae20eaf93e7d94dd52b65046f3e4f290ec7bbc5c6093634
-    .claude/skills/analyze-session/SKILL.md: sha256:c5c028c3044eb7696f325d5159c98f9390a4fb3285e6a25dfb1f4b9c8ce35755
+    .claude/skills/analyze-session/SKILL.md: sha256:5950986f352869013aec81c879eb36aaf5e356bcffe2a61f0ad680e6a57cac18
     .claude/skills/analyze-session/references/FIX_SURFACES.md: sha256:62c012b1713117ea3a5dcb50e256497584eb56baa2f78ae8b0e0cb4cecafa2b0
     .claude/skills/analyze-session/references/LOCATE_SESSION.md: sha256:b060c50fb6d90fd537bd894f011d9bfac5ff61a313e96d817adfafa565f20263
     .claude/skills/analyze-session/references/SESSION_CLI.md: sha256:1128f27554f28a895d4e7eafa8e21ffcb561399168a12eea3cb634197a92d665
-    .claude/skills/analyze-session/references/VERIFY_FIGURES.md: sha256:05cfbca669e4e446819a1099c7e20309b2a480db6f8f6bdd2a94662ad5f8180d
+    .claude/skills/analyze-session/references/VERIFY_FIGURES.md: sha256:ff618916a6d3979d20cdbdd6d904431384a3c6fa2cd768d7e45bf325d12ee05c
     .claude/skills/analyze-session/references/WRITING_THE_RETRO.md: sha256:6b40ccc7b76da3522ad2ddff7ef2f229da24e197906a0df3191b9320a672f999
     .claude/skills/analyze-session/scripts/new-retro.sh: sha256:1c594ccd66c9d97c830f34a326c98cdb892a2237f98e256340fb647f4f7fb6c9
     .claude/skills/analyze-session/scripts/preflight.sh: sha256:ff021bce33efc02454ac8a07004f1e681fb0388d3dd160a581c206bb660212be
     .claude/skills/analyze-session/scripts/session.py: sha256:6e79efa8c241521effd22bf926a43c28d86c5e04cce14fa0ee6ca84e2fcf3c82
     .claude/skills/analyze-session/templates/RETRO.md: sha256:0703f7f280c2e506c50fc9d3de4c03a8b0b1315f197c612e87471de65d726162
-    .claude/skills/analyze-session/tokens.json: sha256:ce52a8d7d098c8c20b668cd36637679394a9370f591ffc402e7f5c56e0f84bdb
+    .claude/skills/analyze-session/tokens.json: sha256:84ef3d3b98b14692fdeb529b4c3f57fa63734c0ed7e10d7d64f3dde460d5e0c2
     .claude/skills/commit/SKILL.md: sha256:5cc1c0bdafecc55f596e3cd12da02bdfb92edc8d75f7cf55218cc3509d59af79
     .claude/skills/commit/scripts/commit.sh: sha256:a7447f831dc940c676a0a76d8644b4c2325ea1a69fe82d1c59ec5b632818ac81
     .claude/skills/commit/scripts/guard-git.sh: sha256:c826480f50e8b10baff853467a5bcd33b838fb13bcb1e0c866a05122d1a74df1
@@ -172,13 +196,13 @@ dependencies:
     .claude/skills/resolve-rebase-conflicts/tokens.json: sha256:9911ba26395219bc9694cacf1645f38dbfd785f4caba2ae4d45dd177ce999f6d
     .claude/skills/review-commit-message/SKILL.md: sha256:5a02ff2ee3419a12dc71b2e298ee97f9d02928e51f92eb769a75762a5866414c
     .claude/skills/review-commit-message/tokens.json: sha256:97d50df77eb89bbba01e7c17408ba6fd228ad036d6c27537660c566d3e77fa05
-    .claude/skills/review-pr-description/SKILL.md: sha256:150aa2fcce0043f8704683b982c026cc569844c41543a774f498f4b07a6dd528
-    .claude/skills/review-pr-description/tokens.json: sha256:9fdf3d0de53316a2e33f1b40a775d95cc8281877dc255e6cf597f991f75e03ff
+    .claude/skills/review-pr-description/SKILL.md: sha256:b2fa9953b074966e66a2a2d4bf9624c57feb62f016a2292525cf8b426ae8871c
+    .claude/skills/review-pr-description/tokens.json: sha256:1c936293cb92087b21ce6605c6af501f3ce658e9e13c7fd88bbf29235049026f
     .claude/skills/review-prose-fix/SKILL.md: sha256:5061db9a99d1833b565047f7888e3c889c5608baf9bb33e0b27ada936d6e7c8a
     .claude/skills/review-prose-fix/tokens.json: sha256:a8199b47458d65d5964a27d0f7cc96e61a0ff45f0dd10344abb21a0c92904e58
-    .claude/skills/review-squash-message/SKILL.md: sha256:ab2bc599f50e01a4bdffa7963fac4e44aa951aff32f741db6be79f447c3d078b
+    .claude/skills/review-squash-message/SKILL.md: sha256:f2000d6712cc4897fc197025c1cf5618ae22a0d4ad4ce1b2eade5491ae377324
     .claude/skills/review-squash-message/scripts/context.sh: sha256:c8feff629fee467eaf0240582f0a30eb54c3b12ee97e5ba205859dabb6951b3c
-    .claude/skills/review-squash-message/tokens.json: sha256:76a94eedf22a4ea1fe8e1ff7a4ed3b8752c851206a9fc117959ec911a2b03a57
+    .claude/skills/review-squash-message/tokens.json: sha256:5b39cf851e414274654ef2b9ac31bd12648be633ffaf2330ee1c4ee8b6b6c871
     .claude/skills/watch-pr/SKILL.md: sha256:174ed7841d50ff09d8b63c7e816f55ce5328a1bd17e267d9a86c652e48f484cb
     .claude/skills/watch-pr/scripts/guard-watch.sh: sha256:6fc489a3c60f9b669fa9290d871532ddf0dbae056f4ce50a7335238030fccba8
     .claude/skills/watch-pr/scripts/watch-checks.sh: sha256:341a13a8e9ddf14f3adadfc2c905ee848357c61a0375bd539edea6710bb49c76
@@ -190,7 +214,37 @@ dependencies:
     .claude/skills/write-prose-fix/SKILL.md: sha256:9b7f0e2c333189ff9ae76d0c084590139120f6a05963c84015eb609cad00bd0b
     .claude/skills/write-prose-fix/scripts/context.sh: sha256:a8f111896e3a438307b1c7467724f8ad43ee25c0234fae7b0939e256ae333aca
     .claude/skills/write-prose-fix/tokens.json: sha256:5e02b07de31ed9fd232c920628a87ba570cb76b7543c43505de645828b31c1dc
-  content_hash: sha256:dcbfad3e0aad74a32d86b3a6d178c0e6307f6f48fca8bb47746d05bd606867c9
+  content_hash: sha256:7575d47397cd8c00ec0b819b84ce1246597fe4709d0269d6b5d0f7c32684fb15
+  declared_license: Apache-2.0
+- repo_url: tbhb/repotools
+  name: repotools-agents-codex
+  host: github.com
+  resolved_commit: 7afd9b223004dca83b415e7871ad63f2a9e1917f
+  resolved_ref: v0.8.0
+  version: 0.8.0
+  virtual_path: packages/agents/codex
+  is_virtual: true
+  depth: 2
+  resolved_by: tbhb/repotools
+  package_type: apm_package
+  content_hash: sha256:bcfb5b4f3ef1d1dfc11144af10bd6157c28bbf1324c850a74a970f139cbf9619
+  declared_license: Apache-2.0
+- repo_url: tbhb/repotools
+  name: repotools-agents-common
+  host: github.com
+  resolved_commit: 7afd9b223004dca83b415e7871ad63f2a9e1917f
+  resolved_ref: v0.8.0
+  version: 0.8.0
+  virtual_path: packages/agents/common
+  is_virtual: true
+  depth: 2
+  resolved_by: tbhb/repotools
+  package_type: apm_package
+  deployed_files:
+  - .claude/rules/worktree-wip.md
+  deployed_file_hashes:
+    .claude/rules/worktree-wip.md: sha256:0204082643d1ea505ae20eaf93e7d94dd52b65046f3e4f290ec7bbc5c6093634
+  content_hash: sha256:5c184e4aa0d108b2a1b70e7751e3f7635881ca235d7ba78ef562cb5a38d686e6
   declared_license: Apache-2.0
 deployments:
 - kind: project-relative
@@ -199,8 +253,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/common
+  active_owner: tbhb/repotools/packages/agents/common
   content_hash: sha256:0204082643d1ea505ae20eaf93e7d94dd52b65046f3e4f290ec7bbc5c6093634
 - kind: project-relative
   target: claude
@@ -208,8 +262,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -217,17 +271,17 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:c5c028c3044eb7696f325d5159c98f9390a4fb3285e6a25dfb1f4b9c8ce35755
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:5950986f352869013aec81c879eb36aaf5e356bcffe2a61f0ad680e6a57cac18
 - kind: project-relative
   target: claude
   value: .claude/skills/analyze-session/references/FIX_SURFACES.md
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:62c012b1713117ea3a5dcb50e256497584eb56baa2f78ae8b0e0cb4cecafa2b0
 - kind: project-relative
   target: claude
@@ -235,8 +289,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:b060c50fb6d90fd537bd894f011d9bfac5ff61a313e96d817adfafa565f20263
 - kind: project-relative
   target: claude
@@ -244,8 +298,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:1128f27554f28a895d4e7eafa8e21ffcb561399168a12eea3cb634197a92d665
 - kind: project-relative
   target: claude
@@ -253,17 +307,17 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:05cfbca669e4e446819a1099c7e20309b2a480db6f8f6bdd2a94662ad5f8180d
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:ff618916a6d3979d20cdbdd6d904431384a3c6fa2cd768d7e45bf325d12ee05c
 - kind: project-relative
   target: claude
   value: .claude/skills/analyze-session/references/WRITING_THE_RETRO.md
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:6b40ccc7b76da3522ad2ddff7ef2f229da24e197906a0df3191b9320a672f999
 - kind: project-relative
   target: claude
@@ -271,8 +325,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:1c594ccd66c9d97c830f34a326c98cdb892a2237f98e256340fb647f4f7fb6c9
 - kind: project-relative
   target: claude
@@ -280,8 +334,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ff021bce33efc02454ac8a07004f1e681fb0388d3dd160a581c206bb660212be
 - kind: project-relative
   target: claude
@@ -289,8 +343,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:6e79efa8c241521effd22bf926a43c28d86c5e04cce14fa0ee6ca84e2fcf3c82
 - kind: project-relative
   target: claude
@@ -298,8 +352,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:0703f7f280c2e506c50fc9d3de4c03a8b0b1315f197c612e87471de65d726162
 - kind: project-relative
   target: claude
@@ -307,17 +361,17 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:ce52a8d7d098c8c20b668cd36637679394a9370f591ffc402e7f5c56e0f84bdb
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:84ef3d3b98b14692fdeb529b4c3f57fa63734c0ed7e10d7d64f3dde460d5e0c2
 - kind: project-relative
   target: claude
   value: .claude/skills/commit
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -325,8 +379,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5cc1c0bdafecc55f596e3cd12da02bdfb92edc8d75f7cf55218cc3509d59af79
 - kind: project-relative
   target: claude
@@ -334,8 +388,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:a7447f831dc940c676a0a76d8644b4c2325ea1a69fe82d1c59ec5b632818ac81
 - kind: project-relative
   target: claude
@@ -343,8 +397,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:c826480f50e8b10baff853467a5bcd33b838fb13bcb1e0c866a05122d1a74df1
 - kind: project-relative
   target: claude
@@ -352,8 +406,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:6307f36ed7388b53849023dd4312660b04601483334d891ae10b23a0dd093e37
 - kind: project-relative
   target: claude
@@ -361,8 +415,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:94d3b98d4273dbc012f0d1c69c668d9fd6542a3032df94e0994b1220e26e9ec8
 - kind: project-relative
   target: claude
@@ -370,8 +424,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ee1b7f40131036241a38a0a8dccb8ae72669255396084880fca909110d902da4
 - kind: project-relative
   target: claude
@@ -379,8 +433,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -388,8 +442,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:acae6205e52546c040e0e4c5eefca120ef3df44c325c2e7d6b52a6ff207e864b
 - kind: project-relative
   target: claude
@@ -397,8 +451,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:54ed5032569419c9a49677822ce89cc253677fe4eee0b2334fc0fe1825cc1af8
 - kind: project-relative
   target: claude
@@ -406,8 +460,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5a9b7ae499dc72ead469684b3b8dadf08b4d00371d2be14c96a462db43ca3b0b
 - kind: project-relative
   target: claude
@@ -415,8 +469,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ed9688d83433ff7e1700255ae02e3dc912faf34dc34bdd9edb22eb02b8032d3a
 - kind: project-relative
   target: claude
@@ -424,8 +478,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:7bbf93c29389b61fc7dbc6aef6d2d9d78de6affa938cadeb4b450d6ba1a30f06
 - kind: project-relative
   target: claude
@@ -433,8 +487,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -442,8 +496,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:fdc2f99e6aba0a540ff8782303d0034adc63c54996e1f8caf41f1f4cf30c2767
 - kind: project-relative
   target: claude
@@ -451,8 +505,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:b3a6a97ec8dd99136a65010aaa156f21f4d1321c2f03dd33c3fa85cefea3d23b
 - kind: project-relative
   target: claude
@@ -460,8 +514,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:4460b7803b94266fd8b191b5561e5b4b6c36015dec191679718577088c38bd14
 - kind: project-relative
   target: claude
@@ -469,8 +523,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:90a27acd92779e4582bbf99c9956f62366fcb85c233e12a05c497292d5a14e4e
 - kind: project-relative
   target: claude
@@ -478,8 +532,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:de4ce16740adec37b29bceeb0e5adbf021dbabeedcd9c7efc63179be479658cc
 - kind: project-relative
   target: claude
@@ -487,8 +541,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:3f7935af5f97859066f49eccb2c9ce68322e419e6fa06a047f54442ab06e8912
 - kind: project-relative
   target: claude
@@ -496,8 +550,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:1d9c9a43c67cd336a626b5af57441fc3a55bef12fe74fbf8ab4b7ea20a77435b
 - kind: project-relative
   target: claude
@@ -505,8 +559,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -514,8 +568,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:418582c9578c4a11e1a224fb4765871c691111de8de29ac82e27821638f14bab
 - kind: project-relative
   target: claude
@@ -523,8 +577,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:4b8d3377751cf151d8a8bf3e6b79715e172bdea4742217b9653562c310b216ca
 - kind: project-relative
   target: claude
@@ -532,8 +586,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ed9688d83433ff7e1700255ae02e3dc912faf34dc34bdd9edb22eb02b8032d3a
 - kind: project-relative
   target: claude
@@ -541,8 +595,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:164ee9756773d7c65c8da430309c42c2dd7b0553616d361c0bd7962c05d0f3d9
 - kind: project-relative
   target: claude
@@ -550,8 +604,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:4ad8fcd535fbc37524cf89baa42632eb40c156c23d0dfff47d22b9aa9caa930a
 - kind: project-relative
   target: claude
@@ -559,8 +613,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:eeaca25d0bce0dc874ad389854e2bd4de77669cfed3da97c9999513652b7011a
 - kind: project-relative
   target: claude
@@ -568,8 +622,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:b54430e9cacb8045163dbc35c73be61de8f69fa236e1b41620fe1b10d0eaca0e
 - kind: project-relative
   target: claude
@@ -577,8 +631,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:9e9ea0add42c635cd2ca21509b041346e816d94296feb46da3903515c06daa40
 - kind: project-relative
   target: claude
@@ -586,8 +640,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -595,8 +649,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5fc5c6e46c7c9c8c6ef6d9fd0c850f10104558127a0c41d97a88e332e13fbca0
 - kind: project-relative
   target: claude
@@ -604,8 +658,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:e4aba4ec72fcc682d6d362c590269358ad295300917a0c25d106d290f3cd7b82
 - kind: project-relative
   target: claude
@@ -613,8 +667,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:48849363413f51369df0eabce051afc97109033a8ad50666e685b1160b4f624a
 - kind: project-relative
   target: claude
@@ -622,8 +676,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:eabf109e3c6e24ff0185dfb6d6f90bc95bd5bb44c8642887c9e8b0085c089829
 - kind: project-relative
   target: claude
@@ -631,8 +685,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:e8a7e913e21a56f29851e614033dcbff888cc7863e70446f2ce8dfc3fe77dedb
 - kind: project-relative
   target: claude
@@ -640,8 +694,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:0836faf6bbb81ef45d612034e6fb67f2de9475a499aac1d5f44f2507c803a953
 - kind: project-relative
   target: claude
@@ -649,8 +703,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:06798be90499be5695209f93076bc8bf6ce1fb4c8145dbd3f85c951488be2575
 - kind: project-relative
   target: claude
@@ -658,8 +712,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:b35dfd96352ffed27d73e91642d003cb270782131a20cc427fe93b1af57c9c74
 - kind: project-relative
   target: claude
@@ -667,8 +721,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -676,8 +730,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:35c39badb3c67e9ddbebbb485b278833afb74548e1421e1ea7a602ad8f350dc1
 - kind: project-relative
   target: claude
@@ -685,8 +739,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:0cb326c120efab5b50969b29e21dacb08d655264b80ccd43ef9b7db7ae7b26db
 - kind: project-relative
   target: claude
@@ -694,8 +748,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:dafe9b3b12a713dc14a32ce48ad1baf93be9bcba62f04e815e57667a746e1efd
 - kind: project-relative
   target: claude
@@ -703,8 +757,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:3125779320b71bfabed81ea9ef4457bce81499a3c7d5f0b2d77e7711a517300d
 - kind: project-relative
   target: claude
@@ -712,8 +766,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:6360aba571f285c1fe98bca30819620524e26172581b20ddee151578243e9a92
 - kind: project-relative
   target: claude
@@ -721,8 +775,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:0e9445ed48bde9c5353f2af537efd803c14982d8d10a21742892b106096aaf8a
 - kind: project-relative
   target: claude
@@ -730,8 +784,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:2a495bd4719d0f6e65612bbdec700bf7cb9bad7458394743f17927f4c1cd4ce2
 - kind: project-relative
   target: claude
@@ -739,8 +793,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:42567bac9bddcb97d16607f0ecde703ccf8aba10cbc89cb32983be5cd88ebb5d
 - kind: project-relative
   target: claude
@@ -748,8 +802,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ef804abfd90fd7ab915141b8d40a3c509c52f54a8578f8b38a308b474aeb9ded
 - kind: project-relative
   target: claude
@@ -757,8 +811,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -766,8 +820,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:a98ee564d8a23370a629ade4f70808c554e016250adc95a5e1c294486fb9bf73
 - kind: project-relative
   target: claude
@@ -775,8 +829,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:e4c96dfc3a69e0c44982d3bfe011805ee64ec41acb6c44cb1d117be81c4a2dad
 - kind: project-relative
   target: claude
@@ -784,8 +838,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:9b97797ebb0174960454aed1a49901e4dbd8d24c078f33168229c6f1eda07008
 - kind: project-relative
   target: claude
@@ -793,8 +847,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:defe2056c3b123d8b9cff870454bf940554f25d5eceaa4ab8630d9c93d89d77c
 - kind: project-relative
   target: claude
@@ -802,8 +856,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:a64762cb87341cb1c4050820790f2eff0b50c07ae6d62e7995136d0ffc070b71
 - kind: project-relative
   target: claude
@@ -811,8 +865,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:93f47713021834b6f5b138c42f48e26c40e41ed760a06a4a268787d25ce3a092
 - kind: project-relative
   target: claude
@@ -820,8 +874,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:9911ba26395219bc9694cacf1645f38dbfd785f4caba2ae4d45dd177ce999f6d
 - kind: project-relative
   target: claude
@@ -829,8 +883,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -838,8 +892,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5a02ff2ee3419a12dc71b2e298ee97f9d02928e51f92eb769a75762a5866414c
 - kind: project-relative
   target: claude
@@ -847,8 +901,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:97d50df77eb89bbba01e7c17408ba6fd228ad036d6c27537660c566d3e77fa05
 - kind: project-relative
   target: claude
@@ -856,8 +910,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -865,26 +919,26 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:150aa2fcce0043f8704683b982c026cc569844c41543a774f498f4b07a6dd528
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:b2fa9953b074966e66a2a2d4bf9624c57feb62f016a2292525cf8b426ae8871c
 - kind: project-relative
   target: claude
   value: .claude/skills/review-pr-description/tokens.json
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:9fdf3d0de53316a2e33f1b40a775d95cc8281877dc255e6cf597f991f75e03ff
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:1c936293cb92087b21ce6605c6af501f3ce658e9e13c7fd88bbf29235049026f
 - kind: project-relative
   target: claude
   value: .claude/skills/review-prose-fix
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -892,8 +946,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5061db9a99d1833b565047f7888e3c889c5608baf9bb33e0b27ada936d6e7c8a
 - kind: project-relative
   target: claude
@@ -901,8 +955,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:a8199b47458d65d5964a27d0f7cc96e61a0ff45f0dd10344abb21a0c92904e58
 - kind: project-relative
   target: claude
@@ -910,8 +964,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -919,17 +973,17 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:ab2bc599f50e01a4bdffa7963fac4e44aa951aff32f741db6be79f447c3d078b
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:f2000d6712cc4897fc197025c1cf5618ae22a0d4ad4ce1b2eade5491ae377324
 - kind: project-relative
   target: claude
   value: .claude/skills/review-squash-message/scripts/context.sh
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:c8feff629fee467eaf0240582f0a30eb54c3b12ee97e5ba205859dabb6951b3c
 - kind: project-relative
   target: claude
@@ -937,17 +991,17 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
-  content_hash: sha256:76a94eedf22a4ea1fe8e1ff7a4ed3b8752c851206a9fc117959ec911a2b03a57
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
+  content_hash: sha256:5b39cf851e414274654ef2b9ac31bd12648be633ffaf2330ee1c4ee8b6b6c871
 - kind: project-relative
   target: claude
   value: .claude/skills/watch-pr
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -955,8 +1009,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:174ed7841d50ff09d8b63c7e816f55ce5328a1bd17e267d9a86c652e48f484cb
 - kind: project-relative
   target: claude
@@ -964,8 +1018,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:6fc489a3c60f9b669fa9290d871532ddf0dbae056f4ce50a7335238030fccba8
 - kind: project-relative
   target: claude
@@ -973,8 +1027,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:341a13a8e9ddf14f3adadfc2c905ee848357c61a0375bd539edea6710bb49c76
 - kind: project-relative
   target: claude
@@ -982,8 +1036,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:21d22a1b5afa9e556004a59b98490300a63bbf16aa86f0f5af82255f509e58dc
 - kind: project-relative
   target: claude
@@ -991,8 +1045,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -1000,8 +1054,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:46c50e61d1b84840d9a919873775b49d93f91a1ca92935f1cc21449fa0d4c341
 - kind: project-relative
   target: claude
@@ -1009,8 +1063,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:8f2963be66de209a31573696847645f7252028a5648ed2b0f97a71cc39ff72d6
 - kind: project-relative
   target: claude
@@ -1018,8 +1072,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:8c0a80c080fa29e231745de949d5821f273f062fc6ae0ed78b6cc4167da8d443
 - kind: project-relative
   target: claude
@@ -1027,8 +1081,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:ff57cfb6f0d6712010c990b77eb0801727541e8287508ca26453749037d565f6
 - kind: project-relative
   target: claude
@@ -1036,8 +1090,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: null
 - kind: project-relative
   target: claude
@@ -1045,8 +1099,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:9b7f0e2c333189ff9ae76d0c084590139120f6a05963c84015eb609cad00bd0b
 - kind: project-relative
   target: claude
@@ -1054,8 +1108,8 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:a8f111896e3a438307b1c7467724f8ad43ee25c0234fae7b0939e256ae333aca
 - kind: project-relative
   target: claude
@@ -1063,6 +1117,6 @@ deployments:
   runtime: null
   scope: project
   owners:
-  - tbhb/repotools
-  active_owner: tbhb/repotools
+  - tbhb/repotools/packages/agents/claude
+  active_owner: tbhb/repotools/packages/agents/claude
   content_hash: sha256:5e02b07de31ed9fd232c920628a87ba570cb76b7543c43505de645828b31c1dc

--- a/apm.yml
+++ b/apm.yml
@@ -12,5 +12,5 @@ target:
   - claude
 dependencies:
   apm:
-    - tbhb/repotools#v0.7.1
+    - tbhb/repotools#v0.8.0
   mcp: []

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,18 +2,18 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.7.1 [skip ci]'
-      sha: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
+      commitTitle: 'chore(version): v0.8.0 [skip ci]'
+      sha: 7afd9b223004dca83b415e7871ad63f2a9e1917f
       tags:
-      - v0.7.1
+      - v0.8.0
     path: .
   path: .config/mise/conf.d
 - contents:
   - git:
-      commitTitle: 'chore(version): v0.7.1 [skip ci]'
-      sha: 9c1ec57c7ca45a9faf8054289fa07e80700fac2d
+      commitTitle: 'chore(version): v0.8.0 [skip ci]'
+      sha: 7afd9b223004dca83b415e7871ad63f2a9e1917f
       tags:
-      - v0.7.1
+      - v0.8.0
     path: .
   path: .repotools
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.7.1
+          ref: v0.8.0
         includePaths:
           - .config/mise/conf.d/**
         newRootPath: .config/mise/conf.d
@@ -31,7 +31,7 @@ directories:
       - path: .
         git:
           url: https://github.com/tbhb/repotools
-          ref: v0.7.1
+          ref: v0.8.0
         includePaths:
           - .repotools/**
         newRootPath: .repotools


### PR DESCRIPTION
## Summary

Moves every `tbhb/repotools` pin site to v0.8.0. The sites are the APM manifest, the `vendir` payload, the pre-commit rev, the Renovate preset, and the reusable-workflow refs. The lockfiles and the deployed `.claude/` copies follow the pins.

## Why

v0.8.0 is the first release of the upstream packages/agents layout, which splits the published root package into per-harness sub-packages. The umbrella pin stays valid because the root manifest resolves the sub-packages transitively, and target intersection keeps the `codex` and `agy` scaffolds out of this `claude`-only consumer, so the pin sites move the same way they always have. The `apm.lock.yaml` churn is the ownership transfer that split implies: deployed paths now belong to the `claude` or `common` sub-package, and virtual entries appear for the sub-packages themselves. Deployed skill copies change where v0.8.0 reworded their documents upstream, and each token sidecar follows its document. The vendored tool delta at this tag is a single pin, rumdl v0.2.53.

## Verification

`mise run repotools:check-pins` reports every pin site on v0.8.0, and `mise run repotools:check-vendored` reports the vendored payload matching what git holds. `mise run lint` and `mise run test` both pass, so the rumdl bump and the redeployed skills clear the full gate set.

## Risk

A bad pin points the hooks, the workflows, and the shared tasks at a release that behaves differently from its predecessor, and the split layout could have deployed the wrong files into `.claude/`. The move commits everything it touches, the pins, the lockfiles, the vendored payload, and the deployed copies alike, so one revert backs it out.

## Related

Upstream release: [tbhb/repotools v0.8.0](https://github.com/tbhb/repotools/releases/tag/v0.8.0).
