### PR TITLE
feat: add the FillerIntensifier rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- vale off -->
+
+### Added
+
+- **FillerIntensifier** (`ai-tells`): New rule. Reports "single" and its cousins riding a determiner that already carries the count: "a single command," "one single flag," "every single time," "no single point of failure," "any single failure," "the single source of truth," plus "a lone exception," "its sole purpose," "a mere formality," "one solitary warning," "a singular focus," and "any one of the checks," which is what "any single" turns into when a writer dodges the alert. Deleting the modifier costs those phrases nothing, which is what makes it an intensifier. The "no single" and "any single" arms are deliberately broad on the package's flag-hard stance: "no single component owns this" needs a recast rather than a deletion, and the alert is there to force that choice. Hyphenated compounds ("a single-threaded server"), grammar's "the singular form," pronoun heads ("no one," "each one," "every one"), and "the single most important," which `AbsoluteAssertions` already owns, all stay out.
+
+<!-- vale on -->
+
 ## [1.29.0] - 2026-08-03
 
 <!-- vale off -->

--- a/EXPERIMENTAL.md
+++ b/EXPERIMENTAL.md
@@ -82,7 +82,7 @@ Measures the CV of paragraph word counts within each section. Flags sections whe
 
 ### SentenceStartRepetition
 
-Counts the first word of each sentence within a section and flags when any single starting word appears in more than 30% of sentences (at least 3 occurrences, at least 6 sentences in section).
+Counts the first word of each sentence within a section and flags when one starting word appears in more than 30% of sentences (at least 3 occurrences, at least 6 sentences in section).
 
 **Research basis:**
 
@@ -179,7 +179,7 @@ A capitalization rule that flags markdown headings using Title Case instead of s
 
 **How it works:** Uses Vale's built-in `capitalization` extension. The relevant settings are `match: $sentence` and `scope: heading`. Acronyms like API and SQL, alongside proper nouns like GitHub, Docker, and PostgreSQL, live in a built-in exceptions list that the rule consults before flagging anything.
 
-**Ordinal prefixes:** The rule's `prefix` setting strips a leading ordinal label before checking the case, with or without a colon. Headings such as `Section 1: Data collection methods`, `Appendix A`, `Chapter IV: The long road home`, and `1.1 Results` stay clean. The rule still checks the rest of the heading, so `Section 1: Data Tables Are Here` still trips it, and the first word after the prefix still needs a capital letter. Recognized labels: Appendix, Chapter, Example, Figure, Part, Phase, Section, Stage, Step, and Table, each followed by a number, a single letter, or a roman numeral. Bare numeric ordinals like `1.1` or `2.` also count.
+**Ordinal prefixes:** The rule's `prefix` setting strips a leading ordinal label before checking the case, with or without a colon. Headings such as `Section 1: Data collection methods`, `Appendix A`, `Chapter IV: The long road home`, and `1.1 Results` stay clean. The rule still checks the rest of the heading, so `Section 1: Data Tables Are Here` still trips it, and the first word after the prefix still needs a capital letter. Recognized labels: Appendix, Chapter, Example, Figure, Part, Phase, Section, Stage, Step, and Table, each followed by a number, one letter, or a roman numeral. Bare numeric ordinals like `1.1` or `2.` also count.
 
 **Adding project-specific exceptions:** Users can add their own exceptions (product names, domain terms) without modifying the rule. Drop the relevant entries into your project's `accept.txt` vocabulary file:
 
@@ -231,13 +231,13 @@ Detects when the same formal transition phrase appears 3+ times within a documen
 <!-- vale off -->
 3. Counts occurrences of 20 common formal transitions (case-insensitive): "Moreover," "Furthermore," "Additionally," "Consequently," "Hence," "Thus," etc.
 <!-- vale on -->
-4. Flags when any single transition appears 3+ times in the same section
+4. Flags when one transition appears 3+ times in the same section
 
 ### SentenceStartEntropy
 
 Measures Shannon entropy of sentence-starting words within document sections. A more nuanced version of SentenceStartRepetition that captures broad diversity rather than just the most repeated opener.
 
-**Research basis:** A section could have no single dominant opener yet still sound monotonous (alternating between just "The" and "This"). Shannon entropy captures this broader pattern.
+**Research basis:** A section could have no dominant opener yet still sound monotonous (alternating between just "The" and "This"). Shannon entropy captures this broader pattern.
 
 **How it works:**
 
@@ -316,7 +316,7 @@ Measures the share of sentences in each section that contain a passive construct
 
 ### NegationDensity
 
-Counts the determiner "no" heading a noun phrase and flags paragraphs holding more than two. The construction is correct English and each instance reads fine, so the rule measures rate rather than judging any single use. It catches the writer who reaches for one negation and never varies it, in the way `TricolonDensityDocument` catches a structure no per-instance rule can see.
+Counts the determiner "no" heading a noun phrase and flags paragraphs holding more than two. The construction is correct English and each instance reads fine, so the rule measures rate rather than judging any use on its own. It catches the writer who reaches for one negation and never varies it, in the way `TricolonDensityDocument` catches a structure no per-instance rule can see.
 
 **How it works:**
 
@@ -353,7 +353,7 @@ Known limitations:
 These patterns need capabilities Tengo can't provide. They'd require a separate tool or a Vale plugin with access to NLP libraries:
 
 - **Elegant variation** — AI's repetition penalty causes unnatural synonym cycling ("the protagonist," "the key player," "the eponymous character" instead of reusing a name). Needs entity resolution and coreference tracking.
-- **One-point dilution** — A single argument restated 10 ways across thousands of words. Needs semantic similarity (sentence embeddings) to detect that paragraphs say the same thing differently.
+- **One-point dilution** — One argument restated 10 ways across thousands of words. Needs semantic similarity (sentence embeddings) to detect that paragraphs say the same thing differently.
 - **Unnecessary inline definitions** — AI inserts appositive definitions ("X, a [definition], does Y") even for audiences that know the term. Needs syntactic parsing to identify appositive structures.
 - **Awkward analogies** — AI generates metaphors that seem superficially plausible but lack cultural specificity. Needs semantic analysis to judge metaphor quality.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ai-tells.ClosingPleasantries = NO
 
 ## Rules included
 
-This package contains 80 rule files covering different categories of AI tells. All rules default to `error` level.
+This package contains 81 rule files covering different categories of AI tells. All rules default to `error` level.
 
 <!-- vale off -->
 
@@ -186,6 +186,7 @@ This package contains 80 rule files covering different categories of AI tells. A
 | `FigurativeLends` | "Lends" as an overused verb for conferring an abstract quality: a structure that "lends itself to" reuse, a study that "lends credence," a detail that "lends weight." Gated on the figurative complement, so literal lending (money, a book) stays quiet; disable the rule for library or finance writing. |
 | `FigurativeDraws` | "Draws" as an overused verb for sourcing and comparison: an argument that "draws on" prior work, a section that "draws a distinction," a heading that "draws attention to" a caveat, a post that "draws to a close." Gated on the figurative complement, so literal drawing (a card, water, a weapon, blood) stays quiet; disable the rule for art or card-game writing. |
 | `FigurativeCasts` | "Casts" as an overused verb for projecting an abstraction: a finding that "casts doubt on" a result, a decision that "casts a long shadow," a rewrite that "casts a wide net." Gated on the figurative complement, so literal casting (a fishing line, metal, a vote, actors) stays quiet; disable the rule for fishing, metalwork, or theater writing. |
+| `FillerIntensifier` | "single" and its cousins riding a determiner that already carries the count: "a single command," "every single time," "no single point of failure," "any single failure," "any one of the checks," "the single source of truth," "a lone exception," "its sole purpose," "a mere formality," "one solitary warning," "a singular focus." Deliberately broad: "no single component owns this" is flagged too, and recasting it takes more than deletion. Hyphenated compounds ("a single-threaded server"), grammar's "the singular form," pronoun heads ("no one," "each one," "every one"), and `AbsoluteAssertions`' "the single most important" stay out. |
 | `FillerPhrases` | Padding and performative sincerity: "a wide range of," "in order to," "honestly," "to be perfectly honest," "the honest truth," etc. |
 | `FormalRegister` | Overly formal vocabulary: "utilize," "facilitate," "commence," etc. |
 | `FormalTransitions` | Formal transitions: "Moreover," "Furthermore," "What's more," "Case in point," etc. |
@@ -361,8 +362,8 @@ AI writing research documents these patterns, but they need analysis beyond Vale
 
 - **Sentence-length uniformity:** AI produces sentences of near-uniform length, roughly 27 words, while human writing varies widely. Requires statistical analysis across the document.
 - **Paragraph-length uniformity:** AI paragraphs tend toward uniform size, typically 3-5 sentences and 60-100 words each. Requires document-level measurement.
-- **Dead metaphor repetition:** AI latches onto a single metaphor and repeats it 5-10 times throughout a piece. Requires tracking metaphor usage across the document.
-- **One-point dilution:** A single argument restated 10 ways across thousands of words — circular repetition disguised as comprehensiveness. Requires semantic analysis.
+- **Dead metaphor repetition:** AI latches onto one metaphor and repeats it 5-10 times throughout a piece. Requires tracking metaphor usage across the document.
+- **One-point dilution:** One argument restated 10 ways across thousands of words — circular repetition disguised as comprehensiveness. Requires semantic analysis.
 - **Elegant variation:** AI's repetition-penalty pushes it to substitute synonyms unnaturally, cycling through "protagonist," "key player," "eponymous character" instead of reusing a name. Requires NLP-level analysis.
 - **Content duplication:** Repeating entire sections or paragraphs verbatim within the same piece. Requires document-level diff analysis.
 - **Unnecessary inline definitions:** AI habitually inserts appositive definitions like "X, a [definition], does Y" even when the audience already knows the term. Too many false positives for token matching.

--- a/styles/ai-tells/FillerIntensifier.yml
+++ b/styles/ai-tells/FillerIntensifier.yml
@@ -1,0 +1,38 @@
+---
+extends: existence
+message: "AI intensifier: '%s'. Delete the intensifier. The determiner already carries the count."
+level: error
+ignorecase: true
+tokens:
+  # "single" riding a determiner that already carries the count is pure
+  # emphasis: "a single command" claims nothing "a command" does not,
+  # and "every single time" is "every time" with a drumroll. The (?!-)
+  # lookahead keeps hyphenated compounds ("a single-threaded server",
+  # "the single-variable form") out of scope, where the word does real
+  # work. "no single" and "any single" are redundant the same way: "no"
+  # already means not one, so "no single component owns this" survives
+  # as "no component owns this alone". Recasting those takes more than
+  # deletion, and forcing that choice is the point of the alert.
+  - "(?:a|one|every|this|that|no|any) single(?!-)"
+
+  # "any one" is what "any single" turns into when a writer dodges the
+  # token above, and it carries the same nothing: "any one of the
+  # checks can veto" is "any of the checks can veto". "no one", "each
+  # one", and "every one" stay out, since those head ordinary pronoun
+  # phrases rather than intensified nouns.
+  - "any one(?!-)"
+
+  # "the single most important" belongs to AbsoluteAssertions, so it is
+  # carved out here rather than double-flagged.
+  - "the single(?!-| most important)"
+
+  # The synonyms take the same ride: "a lone exception", "its sole
+  # purpose", "a mere formality", "one solitary warning". "sole" is
+  # flagged even where legal boilerplate likes it ("the sole
+  # discretion"), on the package's flag-hard stance.
+  - "(?:a|one|the|this|that|its|their|whose) (?:lone|sole|solitary|mere)(?!-)"
+
+  # "a singular focus" is the same intensifier, but "the singular" is
+  # how grammar writing names the number ("the singular form"), so the
+  # definite article stays out for this word alone.
+  - "(?:a|one|this|that|its|their|whose) singular(?!-)"

--- a/styles/ai-tells/StackedAnaphora.yml
+++ b/styles/ai-tells/StackedAnaphora.yml
@@ -1,6 +1,6 @@
 ---
 extends: existence
-message: "AI anaphora: '%s'. Vary the sentence openings or combine into a single statement."
+message: "AI anaphora: '%s'. Vary the sentence openings or combine into one statement."
 level: error
 nonword: true
 tokens:

--- a/test-document.md
+++ b/test-document.md
@@ -1588,3 +1588,37 @@ No animals were harmed in the making of this feature.
 No signup required.
 
 No credit card needed, and no extra tooling necessary.
+
+## Filler intensifiers
+
+The whole pipeline compiles down to a single binary.
+
+One single flag controls the entire rollout.
+
+You have to re-run the bootstrap every single time.
+
+This single abstraction shaped the whole design.
+
+That single decision constrained the architecture for years.
+
+The single source of truth for the pins lives in the manifest.
+
+A single misplaced comma broke the build.
+
+No single component owns the whole pipeline.
+
+Any single failure takes down the whole pipeline.
+
+The fix touched a lone test file.
+
+Its sole purpose is to guard the rebase.
+
+The migration is a mere formality.
+
+The mere presence of the flag changes the behavior.
+
+One solitary warning survived the cleanup.
+
+A singular focus on latency shaped the roadmap.
+
+Any one of the checks can veto the merge.

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -755,3 +755,21 @@ The compatibility shim is no longer needed.
 No one was harmed by the change.
 
 No law required them to file the report.
+
+## FillerIntensifier: precise senses that should NOT trigger
+
+A single-threaded server runs without locks.
+
+The single-variable form silently skips every iteration.
+
+Wrap the value in single quotes before passing it to the shell.
+
+The registry is a singleton behind one accessor.
+
+The singular form of the noun takes no suffix.
+
+The word merely narrows the claim.
+
+A lonely outpost appears in the story's second act.
+
+No one has read the draft yet, and each one of the reviewers is busy.


### PR DESCRIPTION
## Summary

A new core `ai-tells` rule, `FillerIntensifier`, flags `single`, `lone`, `sole`, `solitary`, `mere`, and `singular` riding a determiner that already carries the count, plus `any one`, the substitute a writer uses to avoid the `any single` alert. The package lints its own prose and its own rule messages, so the docs and the `StackedAnaphora` message move off the pattern in the same change, and new fixtures cover the rule in both directions.

## Why

AI-authored prose reaches for these words as emphasis on nouns whose determiners already say how many: adding `single` to "a command" claims nothing the plain phrase does not. Deleting the modifier changes nothing the sentence asserts, which is what makes it filler. The token set is deliberately broad, in line with the package's flag-hard stance: the negated and quantified determiners (`no single`, `any single`) are in even though clearing those alerts takes a recast rather than a plain deletion. The exclusions are the spots where the word distinguishes rather than emphasizes: hyphenated compounds such as `single-threaded`, grammar's `the singular form`, pronoun heads like `no one` and `each one`, and `the single most important`, which `AbsoluteAssertions` already owns.

## Verification

`mise run test` passes, which establishes that `test-false-positives.md`, including the new precise-sense fixtures, produces zero errors. That gate's firing half only checks a corpus-wide alert floor, so `vale --config=.vale-test.ini --output=JSON test-document.md` confirms the rest: `ai-tells.FillerIntensifier` fires on every line of the new fixture block. `mise run lint` exits clean, and that pass includes `mise run lint-messages` over the new rule's message and the reworded `StackedAnaphora` message.

## Risk

The broad token set alerts on prose that treats `sole discretion` or `no single point of failure` as a term of art, and that is deliberate. A project that disagrees turns the rule off in its `.vale.ini` with `ai-tells.FillerIntensifier = NO`. The `StackedAnaphora` edit changes the message text alone, so the output line shape the downstream prose-fix skills parse does not change. Consumers see the new wording on their next `vale sync`. Backing out means reverting the commit, which removes `styles/ai-tells/FillerIntensifier.yml` and restores the docs and fixtures.

## Related

None.
