### PR TITLE
feat(rules): flag the totality claims that mirror the negation pair

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -35,6 +35,7 @@ commitlint
 coreference
 dasel
 dedup
+doctest
 doesn
 dogfooding
 dunder
@@ -84,6 +85,7 @@ optimi
 orbstack
 orcid
 osxkeychain
+overclaim
 Overexplanation
 peakoss
 pipefail
@@ -125,6 +127,7 @@ tombi
 toplevel
 tricolon
 tricolons
+unbuildable
 vendir
 venv
 verbed

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ai-tells.ClosingPleasantries = NO
 
 ## Rules included
 
-This package contains 92 rule files covering different categories of AI tells. All rules default to `error` level.
+This package contains 94 rule files covering different categories of AI tells. All rules default to `error` level.
 
 <!-- vale off -->
 
@@ -234,6 +234,8 @@ This package contains 92 rule files covering different categories of AI tells. A
 | `StrategyBuzzwords` | Strategy-deck buzzword metaphors: "growth flywheel," "competitive moat," "north star metric," "network effects," "first-mover advantage," "land grab." Each is scoped to the figurative shape, so the engine's flywheel, a castle's moat, and the real North Star stay clean. |
 | `StructureAnnouncements` | Narrating upcoming structure: "key takeaway," "quick recap," "to recap," "quick summary," "to put it plainly," "to put this in perspective," etc. |
 | `SycophancyMarkers` | Flattering phrases: "Great question," "I'm happy to help," "You make an excellent point," etc. |
+| `UniversalObject` | The mirror of `NegatedObject`, the universal quantifier on the object: "handles all edge cases," "covers every scenario," "addresses all concerns," "eliminates all ambiguity," "meets every requirement," "passes all checks," "guarantees all deliveries." The self-grading register where a change claims a clean sweep. The verb list is curated against the same pre-LLM corpora, so the operations family stays quiet ("returns all matches," "removes all elements," "finds all occurrences" are spec facts), along with the lock-comment register ("protects all fields"), doctest report output ("passed all tests"), the exception idiom ("eliminates all but the top level"), and the alternation reading of "every other." Base verb forms stay out, so modal and infinitive aspiration ("should handle all cases," "to cover all of them") never fires. Human coverage prose on the listed verbs ("Handles all POST requests") still fires; add project exceptions where a file needs them. |
+| `UniversalSubject` | The passive sibling of `UniversalObject`, the universal quantifier promoted to subject: "All edge cases are handled," "Every concern has been addressed," "All inputs are validated," "Every effort has been made," plus the uncounted scoreboard "All tests pass," "All checks are green." Anchored to a sentence-initial capital, so the mid-sentence conditional ("when all bytes are consumed") stays quiet, as do adjective predicates ("All three parts are optional"), the resumptive floats that summarize a list just named ("X, Y, and Z are all copied," "have all been observed"), and the modal future ("All feedback will be addressed"). Unlike its siblings, the predicate slot is open (any participle) rather than corpus-curated: the docs uniformity sweep ("All tabs are expanded to spaces," "All whitespace is removed") flags on purpose, the same call as the figurative family, because the shape now floods AI prose. Add project exceptions where spec formulas are deliberate. The counted scoreboard ("All 47 tests passing") stays in `CommitTestEnumeration`. |
 | `UnpackExplore` | Explainer announcements: AI's habit of announcing what it is about to explain rather than just explaining it. Phrases beginning with "Let me" or "Let us" followed by unpack, break down, dive in, walk through, examine, explore, etc. |
 | `UrgencyInflation` | False urgency and importance assertions: "cannot be overstated," "more important than ever," "has never been more critical," "the stakes have never been higher," "at a critical juncture," "in an increasingly connected world," etc. |
 | `VagueAttributions` | Claims attributed to unnamed authorities: "experts argue," "studies show that," "research suggests," "a growing body of evidence," etc. |
@@ -471,7 +473,7 @@ Based on academic research, practitioner analysis, and community-maintained cata
 
 ## AI disclosure
 
-Claude wrote the majority of rule definitions, documentation, and test cases in this repository. ChatGPT and Gemini generated text samples for cross-model validation. A human designed the rule categories, severity assignments, quality criteria, and the research-to-rule pipeline. A human validated every AI-generated rule against test documents containing known patterns.
+Claude wrote the majority of rule definitions, documentation, and test cases in this repository. ChatGPT and Gemini generated text samples for cross-model validation. A human designed the rule categories, severity assignments, quality criteria, and the research-to-rule pipeline. A human validated each AI-generated rule against test documents containing known patterns.
 
 The CITATION.cff lists the human author. It omits AI tools, consistent with [Committee for Publication Ethics (COPE) guidance](https://publicationethics.org/guidance/cope-position/authorship-and-ai-tools) on AI and authorship.
 

--- a/styles/ai-tells/UniversalObject.yml
+++ b/styles/ai-tells/UniversalObject.yml
@@ -1,0 +1,66 @@
+---
+extends: existence
+message: "AI totality claim: '%s'. Say which cases were checked, or drop the quantifier."
+level: error
+nonword: true
+ignorecase: true
+# The mirror of NegatedObject: the universal quantifier on the object
+# ("handles all edge cases," "addresses all concerns," "eliminates all
+# ambiguity," "covers every scenario"). Where the shifted "no" claims a
+# clean absence, "all" claims a clean sweep, and AI prose grades its own
+# work with it constantly. The general shape is unbuildable: humans write
+# "returns all matches," "removes all elements," and "finds all
+# occurrences" hundreds of times per million lines, because operating on
+# every element of a collection is a spec fact. Only the overclaim
+# register survives measurement.
+#
+# The verb list is empirical, run against the same ~1.3M lines of pre-LLM
+# human technical prose as NegatedObject (Go stdlib doc comments plus
+# Python stdlib source). The operations family stays out wholesale:
+# "returns all" (37 hits), "removes all" (55 across forms), "find all"
+# (50), "clear all" (33), "delete all" (29), "check all" (32), plus
+# "protects all" (the lock-comment register: "mu protects all fields
+# below") and the past "passed all" (doctest report output: "4 items
+# passed all tests"). The verbs kept below total 36 corpus hits, led by
+# "handles all" (10, the HTTP-dispatcher register: "Handles all POST
+# requests") and "covers all" (6, the coverage-metrics register), and
+# including Python's own joke docstring "This function solves all of the
+# world's problems," which is the tell and flags on purpose.
+#
+# Base forms stay out entirely, and the grammar does the excluding:
+# modals, infinitives, and imperatives take the bare verb, so "should
+# handle all cases," "to cover all of them," "doesn't handle all the
+# non-Latin letters," and "TODO: handle all kinds" never match. That
+# register is aspiration, the opposite of the claim, and it dominates the
+# corpus hits on bare forms. The cost is the first-person present ("we
+# handle all edge cases"), which escapes. Perfect tenses keep the modal
+# hole open through the participle ("should have covered all program
+# counters" laments a gap and still fires); the corpora show one hit.
+#
+# The lookahead after "all" excludes the exception idiom: "eliminates all
+# but the top level" claims an exception, not a sweep. The lookahead
+# after "every" excludes the alternation reading of "every other." One
+# sense collision survives: "passes all encountered errors" forwards
+# them rather than clearing a bar; the corpora show one hit.
+tokens:
+  # --- Coverage claims: what the change is said to blanket ("handles all
+  # edge cases," "covers every scenario," "addresses all concerns,"
+  # "supports all platforms," "considers all inputs," "captures all
+  # state").
+  - "\\b(?:handles|handled|handling|covers|covered|covering|addresses|addressed|addressing|supports|supported|supporting|considers|considered|captures|captured|capturing) (?:all (?!but\\b)|every (?!other\\b))[a-z][-a-z]*\\b"
+  # --- Elimination claims: what is said to be swept away ("eliminates
+  # all ambiguity," "prevents every race," "catches all errors," "avoids
+  # all overhead").
+  - "\\b(?:eliminates|eliminated|eliminating|prevents|prevented|preventing|catches|caught|catching|avoids|avoided|avoiding) (?:all (?!but\\b)|every (?!other\\b))[a-z][-a-z]*\\b"
+  # --- Bars cleared: requirements, tests, and contracts reported as
+  # fully met ("satisfies all constraints," "meets every requirement,"
+  # "passes all checks," "respects all invariants," "honors every
+  # setting," "fulfills all obligations"). "Passed" stays out above.
+  - "\\b(?:satisfies|satisfied|satisfying|meets|met|passes|passing|respects|respected|respecting|honors|honored|honoring|fulfills|fulfilled|fulfilling) (?:all (?!but\\b)|every (?!other\\b))[a-z][-a-z]*\\b"
+  # --- Resolution and assurance: problems reported gone and properties
+  # reported safe ("solves all of the problems," "resolves every
+  # conflict," "fixes all issues," "preserves all behavior," "maintains
+  # every invariant," "guarantees all deliveries," "survives all
+  # restarts," "validates all input," "sanitizes every field,"
+  # "anticipates all failure modes").
+  - "\\b(?:solves|solved|solving|resolves|resolved|resolving|fixes|fixed|fixing|preserves|preserved|preserving|maintains|maintained|maintaining|guarantees|guaranteed|guaranteeing|survives|survived|surviving|validates|validated|validating|sanitizes|sanitized|sanitizing|anticipates|anticipated|anticipating) (?:all (?!but\\b)|every (?!other\\b))[a-z][-a-z]*\\b"

--- a/styles/ai-tells/UniversalSubject.yml
+++ b/styles/ai-tells/UniversalSubject.yml
@@ -1,0 +1,58 @@
+---
+extends: existence
+message: "AI blanket claim: '%s'. Say which cases were checked, or drop the quantifier."
+level: error
+nonword: true
+# The passive sibling of UniversalObject, and the mirror of NegatedSubject:
+# the universal quantifier promoted to subject, with a copula reporting the
+# sweep complete ("All edge cases are handled," "Every concern has been
+# addressed," "All inputs are validated," "Every effort has been made").
+# The completion-report register of an AI summary, and the uniformity
+# sweep of AI documentation ("All errors are logged," "All data is
+# encrypted").
+#
+# The shape is ordinary in pre-LLM documentation too: the same ~1.3M-line
+# Go+Python corpora as NegatedObject show 86 hits, led by the docs
+# uniformity sweep ("All tabs are expanded to spaces," "All whitespace is
+# removed," "All platforms are guaranteed to fault"). This rule flags that
+# register anyway, the same call as the figurative family: the corpus bar
+# informs the count but does not veto the rule once the shape floods AI
+# prose, and a file whose spec formulas are deliberate adds its own
+# exceptions.
+#
+# Case matters, so no ignorecase: the lowercase spelling is the
+# mid-sentence conditional and subordinate clause ("when all bytes are
+# consumed," "until all tasks are done"), which is process description
+# rather than a claim. The sentence-initial capital is the declarative
+# gate, the same proxy NegatedSubject uses for its "No."
+#
+# The predicate slot takes any -ed form plus the irregular participles,
+# rather than a curated list: the adjective predicates that make the
+# curated approach necessary elsewhere ("All three parts are optional,"
+# "All ports are valid") fail the participle shape on their own. An
+# optional adverb slot covers "are properly handled" and "is now covered,"
+# and the "being" alternates cover the status-report progressive ("All
+# concerns are being addressed").
+#
+# The quantifier-float shapes stay out on structure, not cost: "X, Y, and
+# Z are all copied" (36 corpus hits) and "the temps were all aliased"
+# with "have all been observed" (4) resume a list the subject just named, an
+# enumerate-then-summarize move over known members rather than a sweep
+# over an unnamed universe. The future promise ("All feedback will be
+# addressed") also stays out; it claims a plan, not a result, and the
+# modal keeps it out of the copula alternation.
+#
+# The scoreboard token covers the test-status claim with no count: "All
+# tests pass," "Every check passes," "All tests are passing," "All checks
+# green." The counted spelling ("All 47 tests passing") belongs to
+# CommitTestEnumeration in the commit style. One sense collision survives
+# in the corpora: "All tests pass their arguments to the testing methods"
+# forwards rather than clears a bar.
+tokens:
+  # --- Copula form: "All/Every <subject> is/are/was/were/has been
+  # <participle>." Generic -ed predicate plus irregulars, optional adverb.
+  - "\\b(?:All|Every) (?:[A-Za-z][-A-Za-z']* ){1,3}(?:is|are|was|were|has been|have been|is being|are being|is now|are now) (?:[a-z]+ly |now |ever |being )?(?:[a-z][-a-z]*ed|done|made|met|caught|kept|held|run|swept|built|sent|set|taken|given|shown|seen|found|known|written|understood|gone|put|left|read|hidden|chosen|thrown|broken|frozen)\\b"
+  # --- Scoreboard form: the uncounted test-status claim ("All tests
+  # pass," "All checks are green," "Every gate passes," "All suites
+  # passing").
+  - "\\b(?:All|Every) (?:[A-Za-z][-A-Za-z']* ){0,2}(?:test|tests|check|checks|gate|gates|suite|suites|build|builds|pipeline|pipelines|case|cases|scenario|scenarios) (?:pass(?:es|ed|ing)?|(?:is|are) (?:passing|green)|green)\\b"

--- a/test-document.md
+++ b/test-document.md
@@ -1765,3 +1765,65 @@ We revised the employee laptop security policy exception process.
 The incident response playbook revision deadline slipped.
 
 The database connection pool size limit was reached.
+
+## UniversalObject: totality claims that should trigger
+
+The wrapper handles all edge cases in the parser.
+
+The suite covers every scenario the spec describes.
+
+The rewrite addresses all concerns from the review.
+
+The driver supports all platforms and considers every input shape.
+
+The refactor eliminates all ambiguity and prevents every race.
+
+The middleware catches all errors and avoids all overhead on the hot path.
+
+The schema satisfies all constraints and meets every requirement.
+
+The branch passes all checks and respects all invariants.
+
+The loader honors every setting and fulfills all obligations of the contract.
+
+The patch solves all of the reported problems and resolves every conflict.
+
+The release fixes all issues and preserves all existing behavior.
+
+The store maintains every invariant and guarantees all deliveries.
+
+The daemon survives all restarts, validates all input, and sanitizes every field.
+
+The design anticipates all failure modes and captures all state transitions.
+
+## UniversalSubject: blanket claims that should trigger
+
+All edge cases are handled in the wrapper.
+
+Every concern has been addressed in this revision.
+
+All inputs are validated before the write. All fields are sanitized on entry.
+
+Every effort has been made to keep the interface stable.
+
+All errors are logged with full context.
+
+All whitespace is removed from the token stream.
+
+Every scenario is now covered by the suite.
+
+All concerns are being addressed in parallel.
+
+All feedback has been incorporated into the draft.
+
+All the fixtures were updated to match the new shape.
+
+All current spans have been swept.
+
+All tests pass on the release branch.
+
+Every check passes in the pipeline.
+
+All checks are green after the rebase.
+
+All suites passing on main.

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -884,3 +884,45 @@ We updated the config file path yesterday.
 The unit test suite passed on the first try.
 
 New York City Hall opened at nine.
+
+## UniversalObject: operations verbs and excluded shapes that should NOT trigger
+
+The query returns all matches in insertion order.
+
+The pass removes all unused imports and deletes all stale entries.
+
+Use find to list all files under the directory.
+
+The mutex protects all fields below it.
+
+Each item passed all tests in the doctest run.
+
+The team should handle all cases before the freeze.
+
+We plan to cover all of them in the next milestone.
+
+The parser does not handle all the legacy encodings.
+
+The collapse eliminates all but the top level.
+
+The poller handles every other request in the pair.
+
+The loop clears all pending timers on shutdown.
+
+## UniversalSubject: conditionals, adjectives, and floats that should NOT trigger
+
+The reader stops when all bytes are consumed.
+
+If all checks pass, the merge proceeds without review.
+
+All three parts are optional in the pattern.
+
+All ports are valid, including zero.
+
+The reader, the writer, and the closer have all been observed in the trace.
+
+The temps were all aliased to the scratch buffer.
+
+All feedback will be addressed in the next revision.
+
+All callers must check the returned error.


### PR DESCRIPTION
## Summary

Adds `UniversalObject` and `UniversalSubject` to the core style. The first takes the universal quantifier on the object, the self-grading claim that a change `handles all edge cases` or `meets every requirement`. The second takes the quantifier promoted to subject with a copula reporting the sweep complete, `All edge cases are handled`, plus the uncounted test scoreboard, `All tests pass`. The fixtures and the README rule table move with them, and the AI-disclosure sentence in the README itself tripped the new object rule and now vouches for each rule rather than the universe.

## Why

`NegatedObject` and `NegatedSubject` catch the register that announces absence, but the same voice claims too much in the other direction, grading its own work as a clean sweep of an unnamed universe, and no rule owned that shape. The pair splits on mechanics the way the negation pair does. `UniversalObject` earns its verb list against the pre-LLM Go and Python corpora: the operations family is ordinary documentation (`returns all matches`, `removes all elements`) and stays out wholesale, base verb forms stay out so the modal and infinitive aspiration of a task note never fires, and only the self-grading verbs survive. `UniversalSubject` inverts that tradeoff. Its predicate slot is open, gated instead by the sentence-initial capital. The rule takes the docs uniformity sweep (`All tabs are expanded to spaces`) on purpose, the same call the figurative family recorded, because the shape now floods AI prose. Quantifier floats that resume a list the subject just named stay out on structure rather than cost.

## Verification

`mise run test` passes: the corpus error floor holds and `test-false-positives.md` draws no findings. A direct `vale --config=.vale-test.ini test-document.md` run reports findings from both new rules on the positive fixtures. `mise run repotools:lint-yaml` and `mise run lint-messages` pass, so both rule files parse and their messages clear the style's own gates. `cspell` over the changed files reports nothing.

## Risk

Both rules default to `error`, so consumers pick up new findings on sync: human coverage prose on the curated verbs and deliberate spec formulas both flag until a project adds its own exceptions, a cost the rule comments and the README rows state up front. If that tradeoff proves wrong, turn off the pair in `.vale.ini` with `ai-tells.UniversalObject = NO` and `ai-tells.UniversalSubject = NO`, or revert the commit.

## Related

None.
