### PR TITLE
feat(rules): add FigurativeSweeps for the wholesale-motion figure

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -49,6 +49,7 @@ famil
 favourable
 ferr
 frontmatter
+generalisation
 gitignorable
 gitmoji
 goroutines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- vale off -->
+
+### Added
+
+- **FigurativeSweeps** (`ai-tells`): New rule. Extends the figurative-verb family to wholesale motion: a change that "sweeps away" the old behavior, a refactor making "sweeping changes," a problem "swept under the rug," reviewers "swept up in" the excitement, a trend that "swept through" the industry, plus the totality idioms "a clean sweep," "in one sweep," and "one fell swoop." Every token is complement-gated and measured against the Go and Python standard libraries, where the verb's entire presence is the mark-and-sweep collector and a few algorithmic passes; the one match is a Go comment copying registers "in one fell swoop," the tell itself. The audit-pass noun ("a sweep over the docs") stays uncovered as established programmer usage.
+
+<!-- vale on -->
+
 ## [1.30.0] - 2026-08-16
 
 <!-- vale off -->

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ai-tells.ClosingPleasantries = NO
 
 ## Rules included
 
-This package contains 94 rule files covering different categories of AI tells. All rules default to `error` level.
+This package contains 95 rule files covering different categories of AI tells. All rules default to `error` level.
 
 <!-- vale off -->
 
@@ -194,6 +194,7 @@ This package contains 94 rule files covering different categories of AI tells. A
 | `FigurativeDemands` | "Demands" as obligation issued by an abstraction: a migration that "demands care," an edge case that "demands attention," an interface that "demands a closer look." Gated on the complement, so a person demanding a refund and the economics noun stay quiet; disable the rule for labor or economics writing. The determiner-gated bare shape ("the gate demands a clean run") stays in `CommitFigurativeVerbs`. |
 | `FigurativeLives` | "Lives" as location by residence: config that "lives in" a file, logic that "lives upstream," truth that "lives in one place," "where the exemption lives." An open determiner-gated subject with the beings that literally reside (families, species, neighbors) listed as exceptions, so the residence figure fires whatever the artifact; the pre-LLM programmer idiom ("the package lives in") fires by design. Disable the rule for biography or housing writing. |
 | `FigurativeStays` | "Stays" as personified restraint: a check that "stays green," a helper that "stays out of the way," a fix that "stays clear of" the hot path, deciding "what stays in and what stays out." Gated on the complement, so a guest staying at a hotel stays quiet; disable the rule for lodging or travel writing. "Stays quiet" stays in `FigurativeQuiet`. |
+| `FigurativeSweeps` | "Sweeps" as an overused verb for wholesale motion: a change that "sweeps away" the old behavior, a refactor making "sweeping changes," a problem "swept under the rug," reviewers "swept up in" the excitement, a trend that "swept through" the industry, plus the totality idioms "a clean sweep," "in one sweep," and "one fell swoop." Gated on the figurative complement, so the garbage collector's mark-and-sweep, a parameter sweep, and a radar sweep stay quiet, and the audit-pass noun ("a sweep over the docs") stays uncovered as established programmer usage; disable the rule for housekeeping or weather writing. |
 | `FillerIntensifier` | "single" and its cousins riding a determiner that already carries the count: "a single command," "every single time," "no single point of failure," "any single failure," "any one of the checks," "the single source of truth," "a lone exception," "its sole purpose," "a mere formality," "one solitary warning," "a singular focus." Deliberately broad: "no single component owns this" is flagged too, and recasting it takes more than deletion. Hyphenated compounds ("a single-threaded server"), grammar's "the singular form," pronoun heads ("no one," "each one," "every one"), and `AbsoluteAssertions`' "the single most important" stay out. |
 | `FillerPhrases` | Padding and performative sincerity: "a wide range of," "in order to," "honestly," "to be perfectly honest," "the honest truth," etc. |
 | `FormalRegister` | Overly formal vocabulary: "utilize," "facilitate," "commence," etc. |

--- a/styles/ai-tells/FigurativeSweeps.yml
+++ b/styles/ai-tells/FigurativeSweeps.yml
@@ -1,0 +1,55 @@
+---
+extends: existence
+message: "AI overused verb: '%s'. Name the literal action: is removed or is replaced. Disable this rule for housekeeping or weather prose."
+level: error
+nonword: true
+ignorecase: true
+# "Sweeps" is an AI fingerprint for wholesale motion: a change "sweeps away"
+# the old behavior, a refactor makes "sweeping changes," a problem gets
+# "swept under the rug," a migration finishes "in one clean sweep." The verb's
+# entire presence across the Go and Python standard libraries is the
+# mark-and-sweep collector plus a few algorithmic passes ("a backwards sweep
+# over the instructions"), and none of those ever take the figurative
+# complements below, so garbage-collector prose needs no disable. The
+# complement is the discriminator throughout, in the FigurativeSits mold, so
+# no subject gate is needed.
+#
+# The audit-pass noun ("a sweep over the docs," "run a broad sweep") stays
+# uncovered on purpose: it is established programmer usage for a scan pass,
+# this package's own comments use it, and the radar sense makes it closer to
+# literal than to figure.
+tokens:
+  # --- Displacement: the change removes something wholesale ("sweeps away
+  # the old behavior," "swept aside the objection"). Literal housekeeping
+  # ("sweep away the crumbs") fires, so cleaning prose disables the rule.
+  - "\\b(?:sweep|sweeps|sweeping|swept) (?:away|aside)\\b"
+
+  # --- Engulfment: a participant carried off by a current ("swept up in the
+  # excitement," "swept up in the migration").
+  - "\\bswept up in\\b"
+
+  # --- Pervasion: the change moves through the territory like weather ("the
+  # rewrite swept through the codebase," "a trend sweeping across the
+  # industry"). Literal storms and fires take the same shape, so weather and
+  # disaster writing disables the rule.
+  - "\\b(?:sweep|sweeps|sweeping|swept) (?:through|across)\\b"
+
+  # --- The adjective: breadth asserted instead of enumerated ("sweeping
+  # changes," "a sweeping generalization," "sweeping implications"). Gated on
+  # the rhetoric-and-revision noun because the bare word floods on the
+  # garbage-collector gerund; a scenic vista stays quiet by the same gate.
+  - "\\bsweeping (?:change|rewrite|refactor|reform|claim|generalization|generalisation|statement|overhaul|redesign|revision|simplification|assertion|conclusion|update|edit|implication|power)s?\\b"
+  - "\\bsweepingly\\b"
+
+  # --- Concealment: the problem hidden rather than fixed ("swept under the
+  # rug," "sweeping the failure under the carpet"). The optional words cover
+  # an object between the verb and the idiom.
+  - "\\b(?:sweep|sweeps|sweeping|swept) (?:[a-z]+ ){0,3}under the (?:rug|carpet)\\b"
+
+  # --- Totality idioms: everything at once, count unstated ("a clean
+  # sweep," "in one sweep," "in one fell swoop"). The one match across the
+  # Go and Python standard libraries is a Go comment copying registers "in
+  # one fell swoop," which is the tell itself.
+  - "\\bclean sweep\\b"
+  - "\\bin (?:a|one|a single) sweep\\b"
+  - "\\bone fell swoop\\b"

--- a/test-document.md
+++ b/test-document.md
@@ -1646,6 +1646,26 @@ Decide what stays in and what stays out.
 
 The old name stays in the picture.
 
+## FigurativeSweeps
+
+The rewrite sweeps away the old behavior.
+
+The objection was swept aside in review.
+
+Reviewers get swept up in the excitement.
+
+The trend swept through the industry.
+
+The refactor makes sweeping changes to the parser.
+
+The team swept the failure under the rug.
+
+The migration finished with a clean sweep of the flags.
+
+The script renames every file in one sweep.
+
+The change removed all ten call sites in one fell swoop.
+
 ## NegatedObject: stilted verb-plus-no negations that should trigger
 
 The gate allows no inline suppression.

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -785,6 +785,22 @@ He stayed at the hotel near the airport.
 
 The guests stayed in the annex overnight.
 
+## FigurativeSweeps: garbage collection and literal sweeps that should NOT trigger
+
+The garbage collector sweeps unmarked spans in the background.
+
+Background sweeping runs between GC cycles.
+
+The span was swept before the next mark phase.
+
+The compiler performs a backwards sweep over the instructions.
+
+A parameter sweep covers the learning-rate grid.
+
+The radar sweep completes every four seconds.
+
+She sweeps the porch every morning.
+
 ## FigurativeIdioms: literal descent that should NOT trigger
 
 Come down to the lobby when you are ready.


### PR DESCRIPTION
## Summary

A new core rule, `FigurativeSweeps`, extends the figurative-verb family to the verb of wholesale motion: the displacement, engulfment, pervasion, and concealment shapes, the breadth adjective gated on a rhetoric-and-revision noun along with its bare adverb, and the totality idioms including `one fell swoop`.

## Why

The figurative family had no rule for this verb, which agent prose reaches for when a change removes, replaces, or conceals something in bulk. Every verb shape gates on its complement in the `FigurativeSits` mold, so the rule doesn't need a subject gate or an exception list. Measured against the Go and Python standard libraries, the verb's presence is the mark-and-sweep collector and a few algorithmic passes. None of them take the flagged complements. Garbage-collector prose passes with the rule on. One corpus hit remains, a Go comment copying registers in `one fell swoop`. That comment is the tell itself, recorded in the rule comment as the tolerated cost. As established programmer usage, the audit-pass noun ("a sweep over the docs") stays uncovered on purpose. The British spelling of the generalization noun enters `.cspell-words.txt` because the adjective token spells out both variants whole, and cspell reads the unlisted one as unknown fragments.

## Verification

`mise run test` reports the tell corpus firing, the `CommitPastTense` smoke test passing, and the false-positive corpus clean, including the new garbage-collection and literal-sweep fixtures. `mise run lint` exits green across the full pass, `lint-messages` included, so the new rule's message passes under the style's own rules.

## Risk

The rule matches literal housekeeping and weather prose by design: the complement is the only discriminator there, so no subject gate can separate a broom from a refactor. The message points at the disable path, and a consumer turns the rule off with `ai-tells.FigurativeSweeps = NO`. If the complement gating proves too broad in practice, backing out is reverting the commit, since nothing else references the new rule file.

## Related

None.
