### PR TITLE
feat(rules): catch the free relative framing a heading or a prose lead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **FigurativeSweeps** (`ai-tells`): New rule. Extends the figurative-verb family to wholesale motion: a change that "sweeps away" the old behavior, a refactor making "sweeping changes," a problem "swept under the rug," reviewers "swept up in" the excitement, a trend that "swept through" the industry, plus the totality idioms "a clean sweep," "in one sweep," and "one fell swoop." Every token is complement-gated and measured against the Go and Python standard libraries, where the verb's entire presence is the mark-and-sweep collector and a few algorithmic passes; the one match is a Go comment copying registers "in one fell swoop," the tell itself. The audit-pass noun ("a sweep over the docs") stays uncovered as established programmer usage.
+- **ExplainerLeads** (`ai-tells`): New rule. Reports the free relative ("what/why/how the \<subject\> \<verb\>") used as a framing device in prose: the cleft lead-in ("Here's what the change does," "This is why the pin matters," "That's how the pieces fit"), the label before a colon ("What the hook does: it refuses the write," bold markers included), and the sentence-initial pseudo-cleft ("What the hook does is refuse the write," "What this means is"). Every shape gates the subject behind a determiner, so the embedded clause doing real work mid-sentence ("depends on how the shell resolves it") stays out. When and where stay out of the label and pseudo-cleft shapes because a capitalized "When the input is 6:" opens an ordinary conditional clause, which the Go and Python standard libraries confirm is common human prose; measured corpus cost across 1.3M lines is fourteen hits, each one the construction itself rather than a lookalike.
+
+### Changed
+
+- **ExplainerHeadings** (`ai-tells`): Generalized. The rule knew the pronoun-subject forms by name ("Why It Matters," "What It Does") but missed the same heading with a real subject. A new determiner-gated token catches "Why the Pin Exists," "How the Cache Works," "What the Data Shows," and the when/where/who variants, while "How to Configure X" and "What's New" stay out for lack of a determiner.
 
 <!-- vale on -->
-
 ## [1.30.0] - 2026-08-16
 
 <!-- vale off -->

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ai-tells.ClosingPleasantries = NO
 
 ## Rules included
 
-This package contains 95 rule files covering different categories of AI tells. All rules default to `error` level.
+This package contains 96 rule files covering different categories of AI tells. All rules default to `error` level.
 
 <!-- vale off -->
 
@@ -168,7 +168,8 @@ This package contains 95 rule files covering different categories of AI tells. A
 | `EmphaticCopula` | Italicized copula verbs, determiners, and intensifiers for manufactured profundity |
 | `EmptyPadding` | Empty modifiers before a noun the noun does not need: "named stakeholders," "various stakeholders," "respective roles," "given task," "particular concerns," etc. Sequence-based (modifier plus noun), so it casts a wide net and flags literal uses too ("named pipe," "various reasons," "a certain amount"). Deliberately broad; suppress per-section or disable where the literal sense is common. |
 | `EmptyPaddingStacked` | The same empty modifiers with an adjective ahead of the noun: "named operational support," "certain strategic concerns," "various regional teams," etc. A three-token companion to `EmptyPadding` for the modifier-adjective-noun shape, since Vale sequences cannot make the adjective slot optional. Same breadth and the same suppression advice. |
-| `ExplainerHeadings` | Tutorial-blog heading clichés: "Deep Dive," "Under the Hood," "Demystifying X," "Why It Matters," "A Closer Look," etc. |
+| `ExplainerHeadings` | Tutorial-blog heading clichés: "Deep Dive," "Under the Hood," "Demystifying X," "Why It Matters," "A Closer Look," etc. Also the general free-relative heading, a wh-word plus a determiner-gated subject and verb: "Why the Pin Exists," "How the Cache Works," "What the Data Shows." Conventional doc headings ("How to Configure X," "What's New") stay out. |
+| `ExplainerLeads` | The same free relative used as a framing device in prose: the cleft lead-in ("Here's what the change does," "This is why the pin matters"), the label before a colon ("What the hook does: it refuses the write"), and the sentence-initial pseudo-cleft ("What the hook does is refuse the write"). Embedded clauses doing real work mid-sentence ("depends on how the shell resolves it") stay out. |
 | `FalseBalance` | Evasive "both sides" language: "both sides present valid points," "nuanced approach," etc. |
 | `FalseExclusivity` | False insider drama: "nobody talks about," "what most people miss," "the dirty secret," "the elephant in the room," etc. |
 | `FigurativeFalls` | "Falls" as an overused verb for shortcoming, membership, and neglect: a result that "falls short," a design that "falls apart," a case that "falls under" a category or "falls within scope," a task that "falls by the wayside" or "through the cracks," a request that "falls on deaf ears," responsibility that "falls to" a team. Gated on the figurative complement, so literal falling (prices, temperature, night, rain) stays quiet; disable the rule for gravity or weather writing. The past-tense "things fell into place" stays in `NarrativePivots`, and "falls into three categories" stays in `CataphoricForecasting`. |

--- a/styles/ai-tells/ExplainerHeadings.yml
+++ b/styles/ai-tells/ExplainerHeadings.yml
@@ -5,6 +5,14 @@ level: error
 ignorecase: true
 scope: heading
 tokens:
+  # The general free-relative heading: a wh-word, a determiner, then a
+  # subject and its verb ("Why the Pin Exists," "How the Cache Works,"
+  # "What the Data Shows"). The determiner gate keeps the conventional
+  # doc heading out ("How to Configure X," "What's New"), and the two
+  # required words after it hold the shape to subject + verb. A section
+  # that genuinely poses a question fires too ("When the Interpreter
+  # Starts"); rename it to the topic ("Interpreter startup").
+  - "(?:what|why|how|when|where|who) (?:the|this|that|these|those|a|an|each|every|your|our|its) [-'\\w]+ [-'\\w]+"
   - Deep Dive
   - Under the Hood
   - Demystifying

--- a/styles/ai-tells/ExplainerLeads.yml
+++ b/styles/ai-tells/ExplainerLeads.yml
@@ -1,0 +1,46 @@
+---
+extends: existence
+message: "AI explainer lead: '%s'. State the point directly instead of announcing it."
+level: error
+nonword: true
+scope:
+  - "~heading"
+tokens:
+  # ==========================================================================
+  # The free relative ("what/why/how the <subject> <verb>") used as a framing
+  # device in prose rather than as a heading, where ExplainerHeadings covers
+  # it. All three shapes gate the subject behind a determiner, so the
+  # ordinary embedded clause stays clean ("depends on how the shell resolves
+  # it," "explains why the test fails") only when it is doing real work
+  # mid-sentence rather than announcing what follows.
+  # ==========================================================================
+
+  # --- Shape A: the cleft lead-in — a demonstrative copula pointing at the
+  # free relative ("Here's what the change does," "This is why the pin
+  # matters," "That's how the pieces fit"). The announcement adds nothing the
+  # clause it introduces would not say on its own. Corpus cost on 1.3M lines
+  # of Go and Python stdlib prose: ten hits ("That's why the code is ...,"
+  # "This is what the compiler does ..."), each one the construction itself
+  # rather than a lookalike.
+  - "\\b(?:[Hh]ere's|[Hh]ere is|[Tt]his is|[Tt]hat's|[Tt]hat is) (?:exactly |precisely )?(?:what|why|how|when|where) (?:the|this|that|these|those|a|an|each|every|your|our|its) [-'\\w]+ [-'\\w]+"
+
+  # --- Shape B: the free relative as a label before a colon ("What the hook
+  # does: it refuses the write."). The capitalized wh-word anchors the label
+  # position, so a lowercase embedded clause that happens to precede a colon
+  # stays out. Only what/why/how here: a capitalized "When" or "Where" opens
+  # an ordinary conditional clause ("When the input is 6:"), which the Go and
+  # Python stdlib corpora show is common human prose. The colon sits in a
+  # lookahead rather than the match: a bold label puts closing markers
+  # between the clause and the colon ("**What the hook does**:"), and a
+  # match that spans that boundary is not verbatim in the raw line, which
+  # silently drops the alert.
+  - "\\b(?:What|Why|How) (?:the|this|that|these|those|a|an|each|every|your|our|its) [^.!?:\\n]{1,50}(?=:)"
+
+  # --- Shape C: the sentence-initial pseudo-cleft — the free relative as
+  # subject, resolved by a copula ("What the hook does is refuse the write,"
+  # "Why the pin exists is worth explaining"). The capitalized wh-word plus
+  # the trailing copula holds this to the cleft; the plain embedded clause
+  # has neither. When/where stay out for the conditional-clause reason above.
+  # Corpus cost on 1.3M lines of stdlib prose: four hits, one of them "What
+  # this means is," which is the tell whoever wrote it.
+  - "\\b(?:What|Why|How) (?:the|this|that|these|those|a|an|each|every|your|our|its) (?:[-'\\w]+ ){1,3}(?:is|are|was|were)\\b"

--- a/test-document.md
+++ b/test-document.md
@@ -894,6 +894,32 @@ The honest answer is that we don't know yet.
 
 ### The Inner Workings
 
+### Why the Pin Exists
+
+### How the Fixture Guard Works
+
+### What the Data Shows
+
+### When the Hook Runs
+
+### Understanding Where the Time Goes
+
+## ExplainerLeads
+
+Here's what the change does under load.
+
+This is why the pin matters for reproducibility.
+
+That's how the pieces fit together.
+
+What the hook does: it refuses the write.
+
+**What the hook does**: it refuses the write.
+
+Why the pin exists is worth explaining.
+
+What this means is that the pin moved.
+
 ## MarketingHeadings
 
 ### The Ultimate Guide to Vale

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -942,3 +942,29 @@ The temps were all aliased to the scratch buffer.
 All feedback will be addressed in the next revision.
 
 All callers must check the returned error.
+
+## ExplainerHeadings: conventional doc headings that should NOT trigger
+
+### How to Configure Vale
+
+### What's New in the Release
+
+### Frequently Asked Questions
+
+### Installation and Setup
+
+## ExplainerLeads: embedded clauses that should NOT trigger
+
+The recipe depends on how the shell resolves the binary.
+
+The comment explains why the test fails on Linux.
+
+The parser knows where the file is stored on disk.
+
+The question of why the test fails is still open.
+
+When the input is empty: return early.
+
+When a conversion is applied, the value narrows.
+
+Where the page size is small, memory mapping wins.


### PR DESCRIPTION
## Summary

`ExplainerHeadings` gains a determiner-gated token that flags the free-relative heading with any subject ("Why the Pin Exists," "How the Cache Works," "What the Data Shows") rather than only the pronoun forms it knew by name. A new `ExplainerLeads` rule takes the same free relative when it frames prose instead of a heading. It covers the cleft lead-in (`Here's what the change does`), the label before a colon (`What the hook does: it refuses the write`), and the sentence-initial pseudo-cleft (`What the hook does is refuse the write`).

## Why

A wh-word, a determiner, a subject, and its verb make a clause that frames a point instead of stating it, and generated prose uses that frame heavily. `ExplainerHeadings` listed the pronoun-subject headings individually, so "Why It Matters" fired while "Why the Pin Exists" passed. In prose, existing rules named a few fixed openers by hand (`This is why` in `FormalTransitions`, `What this means is` in `RestatementMarkers`), and nothing covered the general free relative behind them. Every new token gates the subject behind a determiner, which keeps conventional doc headings ("How to Configure X," "What's New") out for lack of one. An embedded clause doing real work mid-sentence ("depends on how the shell resolves it") stays out for a different reason. Each prose token requires its own anchor. That anchor is a demonstrative copula ahead of the clause, a capitalized wh-word before a colon, or a capitalized wh-word resolved by a trailing copula. When and where stay out of the label and pseudo-cleft shapes because a capitalized clause they open is ordinarily conditional. The Go and Python standard-library corpora confirm this. What remains costs a handful of corpus hits, each one the construction itself. The label token requires its colon without consuming it because a bold label puts closing markers between the clause and the colon, and vale silently drops an alert whose matched text is not verbatim in the raw line.

## Verification

`mise run test` passes. `vale --config=.vale-test.ini --output=line test-document.md` reports `ExplainerHeadings` on the new free-relative headings and `ExplainerLeads` on each new prose fixture, the bold label included. `ExplainerLeads` also fires on one pre-existing positive fixture (`That is where the exemption lives`), which contains the same cleft lead-in. That line is in the tell corpus, so the firing is a correct catch rather than a leak. `test-false-positives.md` draws no findings with the new conditional-clause and embedded-clause fixtures in place. `mise run lint` exits zero. It prints warning-level findings on lines this branch does not change.

## Risk

This change risks false positives. The heading token and the prose shapes are pattern gates rather than a parser, so a legitimate free relative the corpora did not cover would now draw an error. A consumer backs a rule out with `ai-tells.ExplainerLeads = NO` in `.vale.ini`, or pins the previous release. Reverting the commit removes both the new rule and the heading token together.

## Related

None
