### PR TITLE
feat(rules): close the tense and constraint gaps in FigurativeHolds

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -18,6 +18,7 @@ bgestat
 bincubat
 BLEU
 bliv
+blocklist
 bnurtur
 bresonat
 bstrik

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **ExplainerHeadings** (`ai-tells`): Generalized. The rule knew the pronoun-subject forms by name ("Why It Matters," "What It Does") but missed the same heading with a real subject. A new determiner-gated token catches "Why the Pin Exists," "How the Cache Works," "What the Data Shows," and the when/where/who variants, while "How to Configure X" and "What's New" stay out for lack of a determiner.
+- **FigurativeHolds** (`ai-tells`): Widened. The idiom and promise families gain their past-tense forms ("held water," "held sway," "held the key to," "held the line," "held court," "held at scale"), the line idiom takes the full inflection group ("holding the line"), and the subject-gated survival family gains the progressive with an optional copula ("the trend is still holding"), with the copula paired to the progressive alone so passive belief ("the assumption is widely held") stays out. A new constraint family catches the verb restricting a resource to a bound ("holding network access to an approved-domain allowlist," "held costs to a minimum," "holds request rates to under 100"), gated on the determiner-plus-bound-noun complement after "to"; the gated shape has zero literal hits in the Python standard library, whose hold-to prose concerns references and pointers.
 
 <!-- vale on -->
+
 ## [1.30.0] - 2026-08-16
 
 <!-- vale off -->

--- a/styles/ai-tells/FigurativeHolds.yml
+++ b/styles/ai-tells/FigurativeHolds.yml
@@ -25,20 +25,37 @@ tokens:
   - "\\bhold(?:s|ing)? up (?:well|under|to scrutiny|against)\\b"
   - "\\bheld up (?:well|under|to scrutiny|against)\\b"
   - "\\bhold(?:s|ing)? water\\b"
+  - "\\bheld water\\b"
   - "\\bhold(?:s|ing)? at scale\\b"
+  - "\\bheld at scale\\b"
   - "\\bhold(?:s|ing)? across\\b"
   - "\\bheld across\\b"
 
   # --- Subject-gated survival: an abstraction that persists ("the pattern
-  # holds," "the correlation still holds"). The curated subject is the
-  # gate, since a bare "holds" would flood.
+  # holds," "the correlation still holds," "the result is still holding").
+  # The curated subject is the gate, since a bare "holds" would flood. The
+  # copula pairs only with "holding" so passive belief ("the assumption is
+  # widely held") stays out.
   - "\\b(?:pattern|trend|rule|result|relationship|correlation|observation|logic|argument|analogy|comparison|intuition|assumption|invariant|principle|premise|claim|conclusion) (?:still |no longer |always |generally |mostly |largely )?(?:holds|held)\\b"
+  - "\\b(?:pattern|trend|rule|result|relationship|correlation|observation|logic|argument|analogy|comparison|intuition|assumption|invariant|principle|premise|claim|conclusion) (?:(?:is|was) )?(?:still |no longer |always |generally |mostly |largely )?holding\\b"
 
   # --- Promise and potential: the crystal-ball possession ("holds
   # promise," "holds great potential," "holds the key to").
   - "\\bhold(?:s|ing)? (?:great |much |real |considerable |enormous |immense |significant )?(?:promise|potential|appeal)\\b"
   - "\\bheld (?:great |much |real |considerable |enormous |immense |significant )?(?:promise|potential|appeal)\\b"
   - "\\bhold(?:s|ing)? (?:more |less |little |no |equal |the same )?(?:weight|sway)\\b"
+  - "\\bheld (?:more |less |little |no |equal |the same )?(?:weight|sway)\\b"
   - "\\bhold(?:s|ing)? the key to\\b"
-  - "\\bholds? the line\\b"
+  - "\\bheld the key to\\b"
+  - "\\bhold(?:s|ing)? the line\\b"
+  - "\\bheld the line\\b"
   - "\\bhold(?:s|ing)? court\\b"
+  - "\\bheld court\\b"
+
+  # --- Constraint enforcement: holding an artifact to a bound ("holding
+  # network access to an approved-domain allowlist," "held costs to a
+  # minimum," "holds request rates to under 100"). The bound noun after
+  # "to" is the discriminator; real prose overwhelmingly writes "holds a
+  # reference/pointer to," which this never touches.
+  - "\\b(?:hold(?:s|ing)?|held) (?:[\\w'-]+ ){0,5}to (?:a|an|the|its|their|our) (?:[\\w-]+ ){0,2}(?:allowlist|whitelist|blocklist|denylist|minimum|baseline|budget|threshold|limit|quota|cap|subset|handful|standard|scope)s?\\b"
+  - "\\b(?:hold(?:s|ing)?|held) (?:[\\w'-]+ ){0,5}to (?:under|below|within|at most|no more than)\\b"

--- a/test-document.md
+++ b/test-document.md
@@ -1264,6 +1264,22 @@ The approach holds great promise.
 
 That argument holds little weight.
 
+That excuse never held water.
+
+The old heuristic held sway for years.
+
+Caching held the key to the speedup.
+
+The on-call team held the line during the incident.
+
+The trend is still holding after the rollout.
+
+The proxy works by holding network access to an approved-domain allowlist.
+
+We held infrastructure costs to a minimum.
+
+The gateway holds request rates to under 100 per second.
+
 ## FigurativeRuns
 
 The problem runs deep.

--- a/test-document.md
+++ b/test-document.md
@@ -1272,6 +1272,12 @@ Caching held the key to the speedup.
 
 The on-call team held the line during the incident.
 
+The cache layer is holding the line on latency.
+
+The optimization held at scale.
+
+The staff engineer held court in the design review.
+
 The trend is still holding after the rollout.
 
 The proxy works by holding network access to an approved-domain allowlist.

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -473,6 +473,14 @@ The court holds session on Mondays.
 
 The clamp holds the panel in place.
 
+That assumption is widely held among practitioners.
+
+He held the phone to his ear.
+
+The bracket holds the panel to the frame.
+
+The cache holds a reference to the parent object.
+
 ## AnthropomorphicJustification (adjudication): literal settling that should NOT trigger
 
 We settled on a date for the review.


### PR DESCRIPTION
## Summary

FigurativeHolds gains past-tense tokens for the idiom and promise families, progressive forms for the subject-gated survival family and the line idiom, and a new complement-gated family for the constraint-enforcement sense of the verb, as in `holding network access to an allowlist`. The tell corpus gains a fixture for each new token, and the false-positive corpus gains the shapes the new gates have to leave alone.

## Why

A sample of AI security prose passed the rule untouched: the verb used for restricting a resource to an approved bound had no tokens at all. Probing that sense exposed narrower gaps in the existing families, where some idiom tokens covered only the present forms and the survival family missed the progressive. The new constraint family gates on what follows the preposition. One accepted shape is a determiner and a bound noun, as in `to an approved-domain allowlist`. The other is a comparative bound word, as in `to under 100 per second`. Both shapes separate the figure from literal use. Real prose almost always writes about holding a reference or pointer to something, and neither gate reaches that shape unless the object itself is one of the listed bounds.

## Verification

`mise run test` reports the tell corpus firing, now with a fixture behind each new token, the commit-tense smoke test passing, and zero findings on the false-positive corpus, which now includes literal holds of a phone, a panel, and a reference, plus the passive belief the survival copula must not catch (`the assumption is widely held`). `mise run lint` passes clean, with the changelog entry inside the vale-off fence the file already uses for entries that quote their own tokens.

## Risk

The cost is over-flagging. The past form of the water idiom can match a literal container, the same cost the present form already accepts. A bound noun the gate lists could appear in a literal physical sentence the fixtures did not expect. The change is additive throughout, new tokens in one rule file plus fixtures, a changelog entry, and a cspell word, so backing it out is reverting the commits. Dropping only the changelog entry would let the release recipe publish the widening without notes.

## Related

None
