### PR TITLE
fix(VerbTricolon): rewrite as a POS-tagged sequence rule to stop firing on non-verb comma lists

### DIFF
--- a/styles/ai-tells/VerbTricolon.yml
+++ b/styles/ai-tells/VerbTricolon.yml
@@ -6,10 +6,12 @@ model: known-verb-mistags
 tokens:
   - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
   - tag: ","
-    skip: 8
-  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
     skip: 2
+  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
+    skip: 1
   - tag: ","
-    skip: 8
-  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
     skip: 2
+  - tag: "CC"
+    skip: 0
+  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
+    skip: 1

--- a/styles/ai-tells/VerbTricolon.yml
+++ b/styles/ai-tells/VerbTricolon.yml
@@ -1,95 +1,15 @@
 ---
-extends: existence
+extends: sequence
 message: "AI tricolon: '%s'. Exactly three parallel verbs in series. Restructure or vary the count."
 level: error
-nonword: true
+model: known-verb-mistags
 tokens:
-  # ==========================================================================
-  # Verb tricolons: three parallel verb phrases in a comma series.
-  #
-  # LLMs produce prose where nearly every enumeration is exactly three items
-  # and almost never two or four. This rule flags each instance.
-  #
-  # Optional adverb prefix (?:\w+ly )? catches "carefully analyzes data,
-  # thoroughly processes results, and accurately generates reports."
-  #
-  # Every gap between items excludes terminal punctuation as well as the
-  # comma, because a tricolon is one sentence. Vale flattens a document to a
-  # single string before matching, joining paragraphs with spaces, so a gap
-  # that allowed a period would let three clauses drawn from three separate
-  # sentences read as a series. That is how a slop paragraph of six short
-  # sentences used to report a tricolon it never contained.
-  # ==========================================================================
-
-  # --- Gerund: "[adv] verbing X, [adv] verbing Y, and/or [adv] verbing Z" ---
-  - "\\b(?:\\w+ly )?\\w+ing [^,.!?]+, (?:\\w+ly )?\\w+ing [^,.!?]+, and (?:\\w+ly )?\\w+ing [^.!?]+"
-  - "\\b(?:\\w+ly )?\\w+ing [^,.!?]+, (?:\\w+ly )?\\w+ing [^,.!?]+, or (?:\\w+ly )?\\w+ing [^.!?]+"
-
-  # --- Past tense -ed: "[adv] verbed X, [adv] verbed Y, and/or [adv] verbed Z"
-  - "\\b(?:\\w+ly )?\\w+ed [^,.!?]+, (?:\\w+ly )?\\w+ed [^,.!?]+, and (?:\\w+ly )?\\w+ed [^.!?]+"
-  - "\\b(?:\\w+ly )?\\w+ed [^,.!?]+, (?:\\w+ly )?\\w+ed [^,.!?]+, or (?:\\w+ly )?\\w+ed [^.!?]+"
-
-  # --- Third person -s: "[adv] verbs X, [adv] verbs Y, and/or [adv] verbs Z"
-  - "\\b(?:\\w+ly )?\\w+s [^,.!?]+, (?:\\w+ly )?\\w+s [^,.!?]+, and (?:\\w+ly )?\\w+s [^.!?]+"
-  - "\\b(?:\\w+ly )?\\w+s [^,.!?]+, (?:\\w+ly )?\\w+s [^,.!?]+, or (?:\\w+ly )?\\w+s [^.!?]+"
-
-  # --- Base form after modals -----------------------------------------------
-  - "\\b(?:can|could|will|would|should|shall|may|might|must) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, and (?:\\w+ly )?\\w+ [^.!?]+"
-  - "\\b(?:can|could|will|would|should|shall|may|might|must) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, or (?:\\w+ly )?\\w+ [^.!?]+"
-
-  # --- Base form after pronoun subjects: "They/We/You [adv] verb X, ..." -----
-  # Lowercase arm mirrors the modal arm so mid-sentence "they process X,
-  # validate Y, and format Z" is covered, not just sentence-initial.
-  - "\\b(?:[Tt]hey|[Ww]e|[Yy]ou) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, and (?:\\w+ly )?\\w+ [^.!?]+"
-  - "\\b(?:[Tt]hey|[Ww]e|[Yy]ou) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, or (?:\\w+ly )?\\w+ [^.!?]+"
-
-  # --- Infinitive (shared "to"): "to verb X, verb Y, and/or verb Z" ---------
-  - "\\bto (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, and (?:\\w+ly )?\\w+ [^.!?]+"
-  - "\\bto (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, or (?:\\w+ly )?\\w+ [^.!?]+"
-
-  # --- Infinitive (repeated "to"): "to verb X, to verb Y, to verb Z" --------
-  - "\\bto (?:\\w+ly )?\\w+ [^,.!?]+, to (?:\\w+ly )?\\w+ [^,.!?]+, and to (?:\\w+ly )?\\w+ [^.!?]+"
-  - "\\bto (?:\\w+ly )?\\w+ [^,.!?]+, to (?:\\w+ly )?\\w+ [^,.!?]+, or to (?:\\w+ly )?\\w+ [^.!?]+"
-
-  # --- Base form after colon: "discipline: verb X, verb Y, and/or verb Z" -----
-  # The lookbehind exempts a Conventional Commits subject, where the colon
-  # separates the type from the description rather than introducing a list.
-  # Vale flattens a document to one string before matching, so without it the
-  # colon in "fix:" reaches past the blank line into the body and pairs the
-  # subject with two commas from prose that holds no tricolon at all. A commit
-  # subject carries no terminal punctuation, so nothing else stops the span.
-  # Genuine tricolons in a commit body still fire through the other tokens.
-  - "(?<!^(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\([^)]{1,30}\\))?!?): (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, and (?:\\w+ly )?\\w+ [^.!?]+"
-  - "(?<!^(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\([^)]{1,30}\\))?!?): (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, or (?:\\w+ly )?\\w+ [^.!?]+"
-
-  # ==========================================================================
-  # Asyndetic tricolons: three parallel verb phrases with NO conjunction.
-  # "parse input, call a service method, format output."
-  #
-  # Even punchier than the syndetic form — AI loves the drumroll without
-  # the cymbal crash. Third item uses [^,.!?]+ to prevent matching into
-  # a fourth item in longer lists.
-  # ==========================================================================
-
-  # --- Asyndetic gerund: "verbing X, verbing Y, verbing Z" -----------------
-  - "\\b(?:\\w+ly )?\\w+ing [^,.!?]+, (?:\\w+ly )?\\w+ing [^,.!?]+, (?:\\w+ly )?\\w+ing [^,.!?]+"
-
-  # --- Asyndetic past tense -ed -------------------------------------------
-  - "\\b(?:\\w+ly )?\\w+ed [^,.!?]+, (?:\\w+ly )?\\w+ed [^,.!?]+, (?:\\w+ly )?\\w+ed [^,.!?]+"
-
-  # --- Asyndetic third person -s ------------------------------------------
-  - "\\b(?:\\w+ly )?\\w+s [^,.!?]+, (?:\\w+ly )?\\w+s [^,.!?]+, (?:\\w+ly )?\\w+s [^,.!?]+"
-
-  # --- Asyndetic base form after modals -----------------------------------
-  - "\\b(?:can|could|will|would|should|shall|may|might|must) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+"
-
-  # --- Asyndetic base form after pronoun subjects -------------------------
-  - "\\b(?:[Tt]hey|[Ww]e|[Yy]ou) (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+"
-
-  # --- Asyndetic base form after colon ------------------------------------
-  # Same commit-subject exemption as the syndetic colon tokens above.
-  - "(?<!^(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\([^)]{1,30}\\))?!?): (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+, (?:\\w+ly )?\\w+ [^,.!?]+"
-
-  # --- Subject-verb tricolon: "the [adj] X verbs A, the [adj] Y verbs B, ..." -
-  - "\\b[Tt]he (?:\\w+ ){1,3}\\w+s [^,.!?]+, the (?:\\w+ ){1,3}\\w+s [^,.!?]+, and the (?:\\w+ ){1,3}\\w+s [^.!?]+"
-  - "\\b[Tt]he (?:\\w+ ){1,3}\\w+s [^,.!?]+, the (?:\\w+ ){1,3}\\w+s [^,.!?]+, or the (?:\\w+ ){1,3}\\w+s [^.!?]+"
+  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
+  - tag: ","
+    skip: 8
+  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
+    skip: 2
+  - tag: ","
+    skip: 8
+  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
+    skip: 2

--- a/styles/ai-tells/VerbTricolonDensity.yml
+++ b/styles/ai-tells/VerbTricolonDensity.yml
@@ -1,7 +1,0 @@
----
-extends: occurrence
-message: "AI tricolon: multiple verb tricolons in one paragraph (found %d). Rewrite some with two or four items."
-level: error
-scope: paragraph
-max: 1
-token: '((?:\w+ly )?\w+s [^,]+, (?:\w+ly )?\w+s [^,]+, (?:and|or) (?:\w+ly )?\w+s [^.!?]+|(?:\w+ly )?\w+ing [^,]+, (?:\w+ly )?\w+ing [^,]+, (?:and|or) (?:\w+ly )?\w+ing [^.!?]+|(?:\w+ly )?\w+ed [^,]+, (?:\w+ly )?\w+ed [^,]+, (?:and|or) (?:\w+ly )?\w+ed [^.!?]+)'

--- a/styles/config/dictionaries/known-verb-mistags.dict
+++ b/styles/config/dictionaries/known-verb-mistags.dict
@@ -115,8 +115,11 @@ proxies	VBZ
 proxy	VBZ
 queries	VBZ
 query	VBZ
-queues	VBZ
-queue	VBZ
+# queue/queues deliberately excluded: confirmed a real false positive in
+# production content ("queue degradation" as a noun-compound modifier,
+# where the unconditional override broke a case the tagger already got
+# right on its own). No corresponding real-corpus miss was ever found
+# to justify keeping it.
 renders	VBZ
 render	VBZ
 seeds	VBZ

--- a/styles/config/dictionaries/known-verb-mistags.dict
+++ b/styles/config/dictionaries/known-verb-mistags.dict
@@ -23,10 +23,19 @@
 # standalone Go probe (tokenize + tag, not just consult a dictionary of
 # English ambiguous words), using both an isolated correct-agreement
 # sentence and a three-item adverb+verb tricolon mirroring this rule's own
-# target shape. Base and inflected forms are both included once either form
-# of a word is confirmed mistagging, since the cost of an unnecessary
-# override is near zero and the tagger's context-sensitivity means an
-# untested form of a confirmed-bad word isn't safely assumed correct either.
+# target shape (bare object, no determiner, since that is the AI-cliché
+# register this rule targets and the shape that most reliably surfaces the
+# mistagging). Every candidate that mistagged in the first tricolon sentence
+# was then cross-checked against a second, independently phrased bare-object
+# tricolon in a different domain and word order. About a third of the first
+# round's candidates (build, commit, dispatch, host, merge, parse, and
+# others) did not reproduce on the second sentence and were left out; a
+# single sentence's phrasing is not itself evidence, agreement across two
+# independent ones is. Base and inflected forms are both included once
+# either form of a word is confirmed mistagging, since the cost of an
+# unnecessary override is near zero and the tagger's context-sensitivity
+# means an untested form of a confirmed-bad word isn't safely assumed
+# correct either.
 #
 # Known tradeoff: a forced override is unconditional, so a listed word used
 # as an ordinary noun immediately before a genuine tricolon (e.g. "The
@@ -68,3 +77,63 @@ checks	VBZ
 check	VBZ
 caches	VBZ
 cache	VBZ
+backups	VBZ
+backup	VBZ
+balances	VBZ
+balance	VBZ
+batches	VBZ
+batch	VBZ
+buffers	VBZ
+buffer	VBZ
+exports	VBZ
+export	VBZ
+filters	VBZ
+filter	VBZ
+forwards	VBZ
+forward	VBZ
+imports	VBZ
+import	VBZ
+indexes	VBZ
+index	VBZ
+logs	VBZ
+log	VBZ
+mirrors	VBZ
+mirror	VBZ
+mocks	VBZ
+mock	VBZ
+mounts	VBZ
+mount	VBZ
+patches	VBZ
+patch	VBZ
+pings	VBZ
+ping	VBZ
+polls	VBZ
+poll	VBZ
+probes	VBZ
+probe	VBZ
+proxies	VBZ
+proxy	VBZ
+queries	VBZ
+query	VBZ
+queues	VBZ
+queue	VBZ
+renders	VBZ
+render	VBZ
+seeds	VBZ
+seed	VBZ
+ships	VBZ
+ship	VBZ
+streams	VBZ
+stream	VBZ
+stubs	VBZ
+stub	VBZ
+syncs	VBZ
+sync	VBZ
+tags	VBZ
+tag	VBZ
+triggers	VBZ
+trigger	VBZ
+verifies	VBZ
+verify	VBZ
+wraps	VBZ
+wrap	VBZ

--- a/styles/config/dictionaries/known-verb-mistags.dict
+++ b/styles/config/dictionaries/known-verb-mistags.dict
@@ -1,0 +1,70 @@
+# Lexicon overrides for VerbTricolon.yml's `model: known-verb-mistags`.
+#
+# This is a SEED list, not a complete or principled vocabulary category.
+# prose's statistical tagger (github.com/jdkato/prose/v3, the exact version
+# Vale's go.mod pins) mistags each word below as a noun or adjective in at
+# least one tested context where it's actually being used as a verb. Every
+# entry here was found by testing specific candidate words, not by deriving
+# a general rule for which words need this -- there is almost certainly
+# real-world technical-writing vocabulary that has the same problem and
+# isn't listed here yet. If you hit a tricolon that VerbTricolon still
+# misses, check whether the missed verb mistags with the standalone-probe
+# method below before assuming the rule itself is broken, and add it here
+# if so.
+#
+# The mistagging is position/context-dependent within a sentence (the same
+# word can tag correctly as the first item in a tricolon and incorrectly as
+# the second or third, since the tagger conditions on the preceding one or
+# two tags), so a lexicon override -- which forces the tag unconditionally
+# rather than per-context -- is the reliable fix; testing a word in
+# isolation alone understates the real failure rate.
+#
+# Method: tag real sentences with the exact pinned tagger version via a
+# standalone Go probe (tokenize + tag, not just consult a dictionary of
+# English ambiguous words), using both an isolated correct-agreement
+# sentence and a three-item adverb+verb tricolon mirroring this rule's own
+# target shape. Base and inflected forms are both included once either form
+# of a word is confirmed mistagging, since the cost of an unnecessary
+# override is near zero and the tagger's context-sensitivity means an
+# untested form of a confirmed-bad word isn't safely assumed correct either.
+#
+# Known tradeoff: a forced override is unconditional, so a listed word used
+# as an ordinary noun immediately before a genuine tricolon (e.g. "The
+# service validates X, transforms Y, and writes Z") can produce a second,
+# boundary-extended duplicate alert alongside the correct one. Confirmed
+# this does NOT produce a false positive on prose that isn't already a real
+# tricolon -- tested each word below as a plain noun subject in ordinary,
+# non-tricolon sentences with zero alerts. The cost is redundant noise on
+# an already-real finding, not a new false finding.
+processes	VBZ
+process	VBZ
+generates	VBZ
+generate	VBZ
+results	VBZ
+result	VBZ
+returns	VBZ
+return	VBZ
+targets	VBZ
+target	VBZ
+sources	VBZ
+source	VBZ
+gates	VBZ
+gate	VBZ
+services	VBZ
+service	VBZ
+records	VBZ
+record	VBZ
+tests	VBZ
+test	VBZ
+flags	VBZ
+flag	VBZ
+links	VBZ
+link	VBZ
+branches	VBZ
+branch	VBZ
+routes	VBZ
+route	VBZ
+checks	VBZ
+check	VBZ
+caches	VBZ
+cache	VBZ


### PR DESCRIPTION
## Status

Draft until [`vale-cli/vale#1162`](https://github.com/vale-cli/vale/pull/1162) merges into `v3` (open, depends on [`vale-cli/vale#1169`](https://github.com/vale-cli/vale/pull/1169), also unmerged). That PR adds count-threshold support to `sequence` rules — exactly what's missing to rebuild `VerbTricolonDensity` as a POS-aware rule instead of removing it outright, per the note under Fix below.

## Problem

`VerbTricolon`'s tokens use `\w+` for each "verb" slot, so they match any word, not just verbs. Two false-positive shapes:

- Heading colon-lists of noun phrases: `# SPEC-...: Worker Foundation, Safety Kernel, And Activity Contracts`
- Noun-phrase bullets: `Easier to maintain, consistent patterns, single source of truth`

## Fix

Rewritten as a `sequence` rule reading real POS tags instead of guessing from `\w+`:

```yaml
extends: sequence
model: known-verb-mistags
tokens:
  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
  - tag: ","
    skip: 2
  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
    skip: 1
  - tag: ","
    skip: 2
  - tag: "CC"
    skip: 0
  - tag: "VB|VBD|VBG|VBN|VBP|VBZ"
    skip: 1
```

Every token uses `tag:`, never `pattern:`. Vale's `anchor()` always prefers a `Pattern`-bearing token over tag-only ones regardless of list position, so mixing in a literal `pattern: ","` makes the comma the anchor instead of the verb and breaks the rule.

The `CC` (conjunction) requirement and tightened `skip` windows aren't cosmetic: an earlier version without them passed all local fixtures but produced 62 false positives on a full 717-file real corpus scan. Requiring an explicit "and"/"or" before the third item, the original regex design's real structural signal, cuts that to 27.

**`known-verb-mistags.dict`** (new file, `styles/config/dictionaries/`): the base tagger mistags some technical-writing verbs as nouns (`processes`, `generates`, etc. tag as `NNS` in context). This lexicon forces 45 confirmed-ambiguous words to their correct verb tag. It's an explicit seed list, not a claim of completeness; its own header documents the method for extending it. One entry (`queue`) was added then removed after the full-corpus scan found it broke a correct noun-compound tag ("queue degradation").

**`VerbTricolonDensity.yml`**: removed. Same false-positive mechanism, but `occurrence` (its extension type) has no tag/POS support at all, so it can't be fixed the way `VerbTricolon` was. The fixed `VerbTricolon` already reports one alert per genuine tricolon, so a paragraph with multiple real tricolons already signals density through alert volume.

## Version requirement

Requires Vale >= 3.19.0. `sequenceMatches` truncates matches at the first comma on 3.17.1 and 3.18.0; fixed in 3.19.0 (confirmed by bisecting release builds).

## Test results

- Both false-positive fixtures: no longer fire
- Both genuine-tricolon fixtures, including the `processes`/`generates` mistagging case: fire correctly
- Full 717-file real corpus: 27 alerts remain (down from 62 pre-tightening). Some are structurally real three-verb-conjunction constructs that read as ordinary spec enumeration rather than AI-cliché prose, a distinction this rule can't make on its own, for example `"PR-modified manifest attempts to add, remove, or alter trusted shard metadata"` and `"Caller inventory is completed, reviewed, and reflected in the spec before RED work starts."` Disclosing that as an open limitation, not claiming zero noise.
- Two known gaps, not introduced by this change: an asyndetic sentence-initial imperative and one complex if/then/which sentence still aren't caught, matching the old rule's behavior.
