### PR TITLE
fix(FigurativeOwns): don't truncate the object match at a hyphen or after one modifier word

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -259,6 +259,7 @@ description = "Run the fixture guard: tells fire, past-tense subjects smoke-test
 run = [
   "mise run test-fires",
   "mise run test-commit-past-tense",
+  "mise run test-figurative-owns-span",
   "mise run test-clean",
 ]
 
@@ -318,6 +319,39 @@ check clean 'fix: Resolve race condition in scheduler'
 check clean 'feat(auth): Drop legacy session check'
 rm -rf "$dir"
 [[ "$fail" -eq 0 ]] && echo "CommitPastTense smoke test passed."
+exit "$fail"
+'''
+
+# Smoke-test FigurativeOwns' object-capture span. test-document.md's fire
+# count can't catch a regression here: a truncated match still fires, just
+# with the wrong span, so test-fires' floor stays green either way. This
+# checks the actual matched text reaches the head noun instead of stopping
+# at a hyphen or after one modifier word.
+[tasks.test-figurative-owns-span]
+description = "Smoke-test FigurativeOwns' object-capture span reaches the head noun"
+run = '''
+#!/usr/bin/env bash
+# Deliberately not -e: every case is checked before the result is judged.
+set -uo pipefail
+dir=$(mktemp -d)
+cfg="$dir/smoke.ini"
+subj="$dir/subject.md"
+printf 'StylesPath = %s/styles\nMinAlertLevel = error\n[*]\nBasedOnStyles = ai-tells\n' "$(pwd)" > "$cfg"
+fail=0
+check() {
+  printf '%s\n' "$1" > "$subj"
+  match=$(vale --config="$cfg" --output=JSON "$subj" \
+    | jq -r '[.[][] | select(.Check=="ai-tells.FigurativeOwns")][0].Match // "<no match>"')
+  if [[ "$match" == "$2" ]]; then echo "ok: $1"
+  else echo "FAIL: $1"; echo "  expected: $2"; echo "  actual:   $match"; fail=1
+  fi
+}
+check 'The installer owns the per-host registry.' \
+  'owns the per-host registry'
+check 'The service owns the shared configuration manifest.' \
+  'owns the shared configuration manifest'
+rm -rf "$dir"
+[[ "$fail" -eq 0 ]] && echo "FigurativeOwns span smoke test passed."
 exit "$fail"
 '''
 

--- a/styles/ai-tells/FigurativeOwns.yml
+++ b/styles/ai-tells/FigurativeOwns.yml
@@ -61,9 +61,11 @@ exceptions:
 tokens:
   # --- Possession: a determiner-led object owned by a mechanism ("vendir
   # owns that directory," "git owns the commit," "one rule owns the
-  # phrase"). An optional modifier word sits between the determiner and the
-  # object.
-  - "\\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z]+ )?[a-z]+"
+  # phrase"). Up to three modifier words sit between the determiner and the
+  # object, and the character class covers hyphenated compounds ("the
+  # per-head Dependency Registry") so the match reaches the true head noun
+  # instead of truncating at the hyphen or after one word.
+  - "\\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z][\\w-]* ){0,3}[a-z][\\w-]*"
 
   # --- The object fronted: a relative clause with the owner after its
   # table ("the table it owns," "the columns each stage owns," "the

--- a/styles/ai-tells/FigurativeOwns.yml
+++ b/styles/ai-tells/FigurativeOwns.yml
@@ -61,10 +61,16 @@ exceptions:
 tokens:
   # --- Possession: a determiner-led object owned by a mechanism ("vendir
   # owns that directory," "git owns the commit," "one rule owns the
-  # phrase"). Up to three modifier words sit between the determiner and the
-  # object, and the character class covers hyphenated compounds ("the
-  # per-head Dependency Registry") so the match reaches the true head noun
-  # instead of truncating at the hyphen or after one word.
+  # phrase"). The character class covers hyphenated compounds of any length
+  # ("the per-head Dependency Registry"), so a hyphen never truncates the
+  # match. Up to three modifier words sit between the determiner and the
+  # head noun, which reaches a 4-word noun phrase ("the monitoring-host
+  # PermitOpen implementation," 3 modifiers plus the head). This is a word
+  # count, not real noun-phrase-boundary detection: a 5th modifier word
+  # still truncates the match before the head noun (e.g. "owns the primary
+  # user authentication session cache" matches only through "session"),
+  # reproducing the same defect class this fix otherwise closes, just at a
+  # higher, still-finite threshold.
   - "\\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z][\\w-]* ){0,3}[a-z][\\w-]*"
 
   # --- The object fronted: a relative clause with the owner after its

--- a/test-document.md
+++ b/test-document.md
@@ -2256,6 +2256,10 @@ Upstream owns their wording.
 
 The one owning rule keeps the phrase.
 
+The installer owns the per-host registry.
+
+The service owns the shared configuration manifest.
+
 ## FigurativeClears
 
 The draft cleared every gate on the first try.


### PR DESCRIPTION
## Problem

`FigurativeOwns`'s object-capture pattern:

```
\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z]+ )?[a-z]+
```

Two bugs against real compound nouns:

1. `[a-z]+` doesn't match hyphens, so a hyphenated compound truncates at the hyphen: `"The installer owns the per-host registry"` matches only `owns the per`.
2. The single optional modifier only allows one word before the head noun, so a 3+ word phrase stops short even without a hyphen: `"The service owns the shared configuration manifest"` matches only `owns the shared configuration`.

Both mean an `exceptions` entry on the true head noun (`registry`, `implementation`) never gets a chance to match, since the reported span never reaches it.

## Fix

```diff
 tokens:
-  - "\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z]+ )?[a-z]+"
+  - "\bown(?:s|ing) (?:a|an|the|this|that|its|their|each|every) (?:[a-z][\w-]* ){0,3}[a-z][\w-]*"
   - "\b(?:a|an|the|this|that|its|their|one|each|every) owning [a-z]+\b"
```

With the fix, both examples above match the full noun phrase (`owns the per-host registry`, `owns the shared configuration manifest`), so an `exceptions` entry on the head noun actually takes effect.

## Verification

- Confirmed the bug is still live on `main`, not already fixed.
- Confirmed the fix is valid syntax for the actual regex engine this runs on (Vale pins `jdkato/regexp2/v2`, .NET-flavored, not Go's RE2).
- Tested against a 144-file real technical-writing corpus: no regressions, no new false negatives on genuine ownership metaphors.

## Known limitation

The `{0,3}` modifier cap is a word-count bound, not real noun-phrase-boundary detection. It fails in two directions, not one.

**Overshoot.** On a long modifier chain, the match can include one extra trailing word past the true head noun (`owns the primary configuration file used`, one word past `file`). This is harmless for `exceptions:` matching, an unanchored substring search over the whole span (confirmed against `internal/check/existence.go`), so an exception on the head noun still suppresses the alert correctly. The 163-file/144-sample corpus check above covers this direction.

**Undershoot.** For a noun phrase with 4 or more modifier words, the match still truncates before the head noun. That reproduces the exact defect class this fix otherwise closes, at a higher, still-finite threshold. Example: `"The service owns the primary user authentication session cache."` matches only through `session` and misses `cache` entirely. This isn't rare in the systems/API-documentation register this rule targets: `session cache`, `token registry`, and `manifest schema` are ordinary compounds, not edge cases. The corpus check above didn't test for this direction, so "163 files, zero alerts" speaks only to overshoot.

A fully unbounded fix isn't available today. Vale's `sequence` rule type hits the same fixed-repetition limit (its `min` field unrolls a rep count at compile time, and there's no greedy or until-boundary match). The tagger behind it, `jdkato/prose`, only assigns part-of-speech tags and skips noun-phrase chunking entirely. Raising `{0,3}` shrinks the undershoot window but can't close it.

Added `test-figurative-owns-span`, a smoke test that checks the matched span covers the actual head noun on both originally-reported cases, not only that the rule matches. `test-document.md`'s fire-count floor can't catch a regression here, since a truncated match still counts toward that floor.

Open to widening the cap further, or a different approach if you have one.

