### PR TITLE
build: add tasks for the pre-LLM prose corpora

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -62,6 +62,7 @@ cosplay
 cosplaying
 dasel
 dedup
+docstrings
 doctest
 doesn
 dogfooding
@@ -86,10 +87,13 @@ GOAWAY
 GOEXPERIMENT
 GOFIPS
 gofmt
+GOROOT
 goroutines
 Gorrie
+gsub
 Hana
 ICSE
+ifdef
 ignorecase
 incentivizes
 incentivizing
@@ -130,6 +134,7 @@ orcid
 osxkeychain
 overclaim
 Overexplanation
+PCRE
 peakoss
 pipefail
 pipx
@@ -137,6 +142,7 @@ PNAS
 preapproval
 prek
 prepositionless
+progit
 propagat
 punche
 pyproject
@@ -167,9 +173,11 @@ subordinator
 Supabase
 surfac
 sweepgen
+sysconfig
 tbhb
 Tengo
 Tera
+testdata
 tfvars
 throughlines
 tmpl
@@ -182,6 +190,7 @@ tricolons
 uintptrs
 unbuildable
 undercount
+undercounted
 vendir
 venv
 verbed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,15 @@ vale --config=.vale.ini test-document.md
 mise run test    # the fixture guard: tells fire, subjects smoke-test, no false positives
 ```
 
+**Measuring a candidate token:**
+
+```bash
+mise run corpus-build                          # once per machine, into ~/.cache/vale-ai-tells/corpus
+mise run corpus-grep 'rather than [a-z]+ing'   # count a PCRE pattern per corpus, with sample paragraphs
+```
+
+A token is counted against human technical prose written before the models before it is added to a rule, and the count goes in the rule comment with an example hit or two. The Go and Python standard library corpora are reference prose, and the PEPs, Go proposals, Go blog, Rust RFCs, and Pro Git are explanation and argument, so quote the argumentative ones for a clause-level shape. A count in the tens that is the construction itself stays and gets documented, while one in the hundreds is ordinary English and measures out. Confirm the settled count through Vale over the corpus files, since Vale uses a different regex engine than the grep task. The header of `tools/corpus-build.sh` lists the sources and pins.
+
 **Running the gates:**
 
 Gates from the vendored payload use a `repotools:` prefix. The rest belong to this repository.
@@ -93,6 +102,7 @@ All rules use `error` level by default. Users can override this in their `.vale.
 - `message`: Clear explanation of why the rule flags the pattern
 - `level`: Always `error`
 - `tokens` or `swap`: The patterns to match
+- A comment recording what the tokens cost on the pre-LLM corpora and what was measured out, from the corpus tasks above
 
 Messages must pass the `ai-tells` style themselves. Avoid em-dashes and anthropomorphic or cliché idioms. Name the good word rather than quoting the flagged one. Write each message as `AI <label>: '%s'. <concrete action>.` so agents can act on it. `mise run lint-messages` enforces this via the `RuleMessage` View (selects the `message` field with Dasel and lints it as prose). It runs as part of `mise run lint`.
 

--- a/mise.toml
+++ b/mise.toml
@@ -418,6 +418,30 @@ echo "  Grand total: $((total + commits_total))"
 
 # --- Aggregators ---
 
+# --- Corpus ---
+
+# The pre-LLM prose corpora a candidate token is counted against before
+# it lands. tools/corpus-build.sh explains the sources and the pins. The
+# output lives in the cache, outside the repository.
+
+[tasks.corpus-build]
+description = "Build the pre-LLM prose corpora a new rule is measured against"
+usage = 'flag "--force" help="Rebuild every corpus file even if it exists"'
+run = "bash tools/corpus-build.sh ${usage_force:+--force}"
+
+[tasks.corpus-grep]
+description = "Count a PCRE pattern across every corpus, case-insensitive, with sample paragraphs"
+usage = 'arg "<pattern>"'
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+dir="${VALE_AI_TELLS_CORPUS_DIR:-$HOME/.cache/vale-ai-tells/corpus}"
+for f in "$dir"/*.txt; do
+  printf '%-16s %s\n' "$(basename "$f" .txt)" "$(rg -icP -- "$usage_pattern" "$f" || echo 0)"
+done
+rg --no-filename -iP -- "$usage_pattern" "$dir"/*.txt | cut -c1-200 | head -n 8
+'''
+
 [tasks.check]
 description = "Fast quality bar: lint then test"
 run = ["mise run lint", "mise run test"]

--- a/tools/corpus-build.sh
+++ b/tools/corpus-build.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# corpus-build — assemble the pre-LLM prose corpora a new rule is measured
+# against, one paragraph per line, in a cache directory outside the repo.
+#
+# A rule's fixtures prove it fires. They say nothing about what it wrongly
+# flags, and the register that trips a rule (a PEP rejecting an
+# alternative, a blog post walking through a mechanism) is invisible from
+# inside this repository's own docs. So every candidate token is counted
+# against human technical prose written before LLM drafting existed, and
+# the count goes in the rule comment.
+#
+# Two kinds of source. The stdlib comments and docstrings come off this
+# machine's Go and Python installs and cover the reference register, terse
+# prose next to the thing it describes. The four published sources cover
+# explanation and argument, which is the register the padding rules
+# target: design rationale (PEPs, Go proposals, Rust RFCs), and the
+# explainer voice (the Go blog, Pro Git). Each published source is a
+# GitHub archive at a commit pinned before 2022-06-01, so the text
+# predates the models, and the pin makes every session count the same
+# words.
+#
+# Output: one paragraph per line with a blank line after it. One line per
+# paragraph means a clause-level shape spanning a wrapped line still
+# counts, which the earlier line-per-comment extraction undercounted, and
+# the blank line means Vale reads each paragraph as its own context. Code
+# blocks, headings, tables, directives, and front matter are dropped;
+# paragraphs under five words are dropped as fragments.
+#
+# Usage: bash tools/corpus-build.sh [--force]
+#   VALE_AI_TELLS_CORPUS_DIR overrides ~/.cache/vale-ai-tells/corpus.
+#
+# Then count with ripgrep (PCRE, case-insensitive):
+#   rg -icP -- '<pattern>' "$CORPUS_DIR"/*.txt
+# or lint through Vale itself, since regexp2 and PCRE differ:
+#   vale --config=<ini> --filter='.Name=="ai-tells.<Rule>"' <corpus>.md
+
+set -euo pipefail
+
+CORPUS_DIR="${VALE_AI_TELLS_CORPUS_DIR:-$HOME/.cache/vale-ai-tells/corpus}"
+SRC_DIR="$CORPUS_DIR/src"
+FORCE=0
+[ "${1:-}" = "--force" ] && FORCE=1
+mkdir -p "$SRC_DIR"
+
+# --- Reflow filters. Each reads one file on stdin and prints paragraphs.
+# A paragraph ends at a blank line or at a line that opens a list item, so
+# adjacent items never merge. Paragraphs under five words drop as fragments.
+
+reflow_common='
+function flush() {
+  if (para != "") {
+    gsub(/[ \t]+/, " ", para)
+    sub(/^ /, "", para); sub(/ $/, "", para)
+    n = split(para, w, " ")
+    if (n >= 5) print para "\n"
+  }
+  para = ""
+}
+function add(line) {
+  sub(/^[ \t]+/, "", line)
+  para = para " " line
+}
+'
+
+# Markdown: fenced code, indented code, headings, tables, HTML, link
+# reference definitions, template directives, and YAML front matter drop.
+reflow_markdown="$reflow_common"'
+NR == 1 && /^---[ \t]*$/ { fm = 1; next }
+fm == 1 { if (/^---[ \t]*$/) fm = 0; next }
+/^[ \t]*(```|~~~)/ { fence = !fence; next }
+fence { next }
+/^[ \t]*$/ { flush(); next }
+/^(    |\t)/ { next }
+/^[ \t]*(#|\||<|\{\{|\[[^]]*\]:)/ { next }
+/^[ \t]*([-*+]|[0-9]+\.)[ \t]/ { flush(); add($0); next }
+{ add($0) }
+END { flush() }
+'
+
+# reStructuredText (the PEPs): the header block up to the first blank
+# line, underline rules, directives, field lists, and indented blocks
+# (literal blocks and block quotes both) drop. A list item keeps its
+# continuation lines, which sit two or three spaces in.
+reflow_rst="$reflow_common"'
+BEGIN { header = 1 }
+header == 1 { if (/^[ \t]*$/) header = 0; next }
+/^[ \t]*$/ { flush(); in_list = 0; next }
+/^[=\-~*^"#`:.+_]{3,}[ \t]*$/ { next }
+/^[ \t]*(\.\.|:)/ { next }
+/^(  |\t)/ { if (in_list && $0 ~ /^ {2,3}[^ ]/) add($0); next }
+/^([-*+]|[0-9]+\.|#\.)[ \t]/ { flush(); in_list = 1; add($0); next }
+{ add($0) }
+END { flush() }
+'
+
+# AsciiDoc (Pro Git): delimited blocks, headings, block titles, attribute
+# lines, macros, comments, tables, and indented literals drop; index
+# markers and callouts strip inline.
+reflow_asciidoc="$reflow_common"'
+/^(----|\.\.\.\.|====|\+\+\+\+|____|\*\*\*\*)[ \t]*$/ { block = !block; next }
+block { next }
+/^[ \t]*$/ { flush(); next }
+/^(\[|=|\.[A-Za-z]|image::|include::|\/\/|\||ifdef::|endif::|:)/ { next }
+/^(  |\t)/ { next }
+{ gsub(/\(\(\([^)]*\)\)\)/, ""); gsub(/<[0-9]+>/, "") }
+/^[ \t]*([-*+]|[0-9]+\.)[ \t]/ { flush(); add($0); next }
+{ add($0) }
+END { flush() }
+'
+
+# Go doc comments: every // line with the marker stripped; a non-comment
+# line ends the paragraph. Build tags and directives drop.
+reflow_go_comments="$reflow_common"'
+/^[ \t]*\/\/[ \t]*$/ { flush(); next }
+/^[ \t]*\/\/(go:|[ \t]*\+build|[ \t]*export )/ { next }
+/^[ \t]*\/\// { line = $0; sub(/^[ \t]*\/\/ ?/, "", line); if (line ~ /^\t/) next; add(line); next }
+{ flush() }
+END { flush() }
+'
+
+# Python: # comment runs and the bodies of triple-quoted strings.
+reflow_python="$reflow_common"'
+{
+  line = $0
+  q = gsub(/"""|'"'''"'/, "", line)
+  if (q > 0) { in_doc = (in_doc + q) % 2; if (line ~ /^[ \t]*$/) { flush(); next } ; if (q == 2 && in_doc == 0) { add(line); flush(); next } ; add(line); if (!in_doc) flush(); next }
+}
+in_doc { if ($0 ~ /^[ \t]*$/) flush(); else add($0); next }
+/^[ \t]*#[ \t]*$/ { flush(); next }
+/^[ \t]*#/ { line = $0; sub(/^[ \t]*#+ ?/, "", line); if (line ~ /^!/) next; add(line); next }
+{ flush() }
+END { flush() }
+'
+
+# --- Sources.
+
+fetch() {  # name repo sha
+  local name="$1" repo="$2" sha="$3"
+  local tree="$SRC_DIR/$name-$sha"
+  if [ -d "$tree" ]; then echo "  $name: cached $sha"; return; fi
+  echo "  $name: fetching $repo@$sha"
+  mkdir -p "$tree"
+  curl -sSL "https://github.com/$repo/archive/$sha.tar.gz" | tar -xz -C "$tree" --strip-components=1
+}
+
+build() {  # name filter find-args...
+  local name="$1" filter="$2"; shift 2
+  local out="$CORPUS_DIR/$name.txt"
+  if [ -s "$out" ] && [ "$FORCE" = 0 ]; then echo "  $name: kept $(grep -c . "$out") paragraphs"; return; fi
+  : > "$out"
+  find "$@" -print0 | sort -z | while IFS= read -r -d '' f; do
+    awk "$filter" "$f" >> "$out"
+  done
+  echo "  $name: $(grep -c . "$out") paragraphs"
+}
+
+echo "corpus: $CORPUS_DIR"
+
+echo "published sources, pinned before 2022-06-01"
+fetch peps        python/peps      1dae9310db2d0c5459c9ed0a4f444a902dcf8085
+fetch go-proposal golang/proposal  e0113ba8479092562cf9d6d4e0e65d3268c2067a
+fetch go-blog     golang/website   ec0d7080e70a7886425b953ab2604510f1d1d55c
+fetch rust-rfcs   rust-lang/rfcs   9925276189646646beffbc4f84ca03b037ff7569
+fetch progit      progit/progit2   20156cdff88e8d67438c24a0ebaf913e7bbdcd41
+
+echo "extracting"
+build peps        "$reflow_rst"      "$SRC_DIR"/peps-*        -maxdepth 1 -name 'pep-*.txt' -o -maxdepth 1 -name 'pep-*.rst'
+build go-proposal "$reflow_markdown" "$SRC_DIR"/go-proposal-*/design -name '*.md'
+build go-blog     "$reflow_markdown" "$SRC_DIR"/go-blog-*/_content/blog -name '*.md'
+build rust-rfcs   "$reflow_markdown" "$SRC_DIR"/rust-rfcs-*/text -name '*.md'
+build progit      "$reflow_asciidoc" "$SRC_DIR"/progit-*/book -name '*.asc'
+
+echo "local stdlib sources"
+if command -v go >/dev/null 2>&1; then
+  build go-stdlib "$reflow_go_comments" "$(go env GOROOT)/src" -name '*.go' -not -name '*_test.go' -not -path '*/testdata/*'
+else
+  echo "  go-stdlib: skipped, no go on PATH"
+fi
+if command -v python3 >/dev/null 2>&1; then
+  build python-stdlib "$reflow_python" "$(python3 -c 'import sysconfig;print(sysconfig.get_paths()["stdlib"])')" -name '*.py' -not -path '*/test/*' -not -path '*/tests/*' -not -path '*/site-packages/*'
+else
+  echo "  python-stdlib: skipped, no python3 on PATH"
+fi
+
+echo "done: $(cat "$CORPUS_DIR"/*.txt | grep -c .) paragraphs across $(ls "$CORPUS_DIR"/*.txt | wc -l | tr -d ' ') corpora"

--- a/tools/corpus-build.sh
+++ b/tools/corpus-build.sh
@@ -134,13 +134,19 @@ END { flush() }
 
 # --- Sources.
 
+# The archive extracts into a partial directory that becomes the cached
+# tree only once the whole pipeline succeeds. A failed download therefore
+# leaves nothing a later run could mistake for a cache hit, and the build
+# stops here rather than writing an empty corpus.
 fetch() {  # name repo sha
   local name="$1" repo="$2" sha="$3"
   local tree="$SRC_DIR/$name-$sha"
   if [ -d "$tree" ]; then echo "  $name: cached $sha"; return; fi
   echo "  $name: fetching $repo@$sha"
-  mkdir -p "$tree"
-  curl -sSL "https://github.com/$repo/archive/$sha.tar.gz" | tar -xz -C "$tree" --strip-components=1
+  rm -rf "$tree.partial"
+  mkdir -p "$tree.partial"
+  curl -fsSL "https://github.com/$repo/archive/$sha.tar.gz" | tar -xz -C "$tree.partial" --strip-components=1
+  mv "$tree.partial" "$tree"
 }
 
 build() {  # name filter find-args...


### PR DESCRIPTION
## Summary

Adds `tools/corpus-build.sh` and two mise tasks, `corpus-build` and `corpus-grep`, that assemble the pre-LLM prose corpora a candidate token is counted against and count a pattern across them. `CLAUDE.md` now points rule work at those tasks and lists the corpus comment as a required part of a rule.

## Why

The counts in the rule comments already on main came from a one-off extraction of the Go and Python standard library comments, redone by hand each time. That extraction wrote one line per comment line, so it counted a clause-level shape spanning a wrapped line too low. Output with each paragraph on one line fixes that. Both standard libraries are also reference prose, terse text beside the thing it describes, while the padding rules target explanation and argument, so a count taken there describes the register least likely to produce the construction. The script pins the PEPs, the Go proposals and blog, the Rust RFCs, and Pro Git at commits from before mid-2022. They cover that register.

## Verification

`VALE_AI_TELLS_CORPUS_DIR=<empty directory> mise run corpus-build` fetched every pinned archive and extracted a corpus for each one plus the local Go and Python standard libraries, printing a paragraph count per corpus. A second `mise run corpus-build` against the existing cache took the cached path for every archive and kept every corpus file. Running the script's fetch function against an archive that does not exist exited nonzero and left only a partial directory, and the next run fetched that archive again instead of reporting a cache hit. A `mise run corpus-build` against the intact cache afterwards still reported every archive cached. `mise run corpus-grep 'rather than [a-z]+ing'`, the pattern from the `CLAUDE.md` example, printed a per-corpus count and sample paragraphs. `mise run lint` exited 0 with only the warning-level findings already present on main, and `mise run lint-draft CLAUDE.md` didn't report an error.

## Risk

Nothing on the release path changes. The corpus tasks write to the cache outside the repository and no gate depends on them, so a broken filter or a dead archive URL costs a rule author a count rather than a build. If a pinned archive stops resolving, the script fails at the fetch and a later run finds no cache hit to skip. Backing the change out means reverting the branch, which leaves behind only a cache directory the operator can delete.

## Related

None
