### PR TITLE
docs: install the core style by its catalog name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- vale off -->
+
+### Changed
+
+- **Installation**: The README snippet now installs `ai-tells` by name. Vale's package catalog lists the style, so `Packages = ai-tells` reaches the latest release without a version in the line. A release URL still pins a version, and `ai-tells-commits` keeps one because the catalog does not list it; Vale syncs a list that mixes the two forms.
+
+<!-- vale on -->
+
 ## [1.33.0] - 2026-09-06
 
 <!-- vale off -->

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the package to your `.vale.ini`:
 StylesPath = styles
 MinAlertLevel = suggestion
 
-Packages = https://github.com/tbhb/vale-ai-tells/releases/download/v1.33.0/ai-tells.zip, \
+Packages = ai-tells, \
   https://github.com/tbhb/vale-ai-tells/releases/download/v1.33.0/ai-tells-commits.zip
 
 [*.md]
@@ -31,6 +31,8 @@ Then run:
 ```bash
 vale sync
 ```
+
+The bare `ai-tells` name works because [Vale's package catalog](https://vale.sh/explorer) lists the style and points that name at the latest release. Name a release URL instead to pin a version. The `ai-tells-commits` style is not in the catalog, so it installs by URL either way.
 
 The `ai-tells-experimental` structural rules install as a separate opt-in package with their own steps, described in [EXPERIMENTAL.md](EXPERIMENTAL.md). The `.vale.ini` at the root of this repository is a development setup that turns on every style at once, so build your own configuration from the install snippet rather than from that file.
 


### PR DESCRIPTION
## Summary

The README install snippet names `ai-tells` where it used to name a release URL, and a paragraph after the snippet says what that name resolves to and how to pin a version instead. `CHANGELOG.md` records the change under Unreleased.

## Why

Vale's package catalog lists `ai-tells` and points the bare name at the latest release. The old snippet pinned an exact tag that every release has to bump by hand, so a reader who copied the snippet stayed on whichever release was current the day they copied it with nothing in the line to say a newer one existed. `ai-tells-commits` is not in the catalog, so it keeps its release URL, and Vale syncs a `Packages` list that mixes the two forms.

## Verification

Wrote the new snippet to a `.vale.ini` in a scratch directory and ran `vale sync` there: both packages installed. `diff -rq` between the synced `styles/ai-tells` and this repository's `styles/ai-tells` didn't report a difference, so the catalog name resolved to the current release. `vale` over `README.md` and `CHANGELOG.md` reported nothing on the lines this branch touches.

## Risk

A reader following the snippet now tracks the latest release rather than a fixed one, so a rule added in a later release starts firing on their documents without them editing anything. The paragraph after the snippet gives the release-URL form for anyone who wants a pin. Nothing outside the two documents changes, and reverting the commit restores the pinned URL.

## Related

None.
