### PR TITLE
fix(EmphaticCopula): don't fire inside bold markup, only italics

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -54,6 +54,7 @@ cli
 cocogitto
 codebook
 codespell
+Coffman
 colour
 commitlint
 concatstring

--- a/styles/ai-tells/EmphaticCopula.yml
+++ b/styles/ai-tells/EmphaticCopula.yml
@@ -5,28 +5,40 @@ level: error
 nonword: true
 scope: raw
 tokens:
+  # Every asterisk token is wrapped (?<!\*)\*(?!\*) ... (?<!\*)\*(?!\*) rather
+  # than a bare \*word\*. A bare pattern matches its middle two asterisks
+  # inside **word** (bold), because "**word**" contains the literal substring
+  # "*word*" once the outer asterisks are counted in. The lookaround requires
+  # each delimiting asterisk to be a single, unpaired one: not preceded or
+  # followed by another asterisk. That excludes **bold** (both delimiters are
+  # doubled) and ***bold+italic*** (tripled) along with plain **word**,
+  # leaving genuine single-asterisk _italic_-only emphasis as the only match.
+  # Underscore tokens don't need the same guard: __word__ (bold) never
+  # contains the literal substring " _word_" the space-prefixed pattern
+  # requires, because the run of underscores is unbroken.
+  #
   # Markdown italicized copula verbs - the "manufactured profundity" pattern
   # Note: underscore patterns require space prefix to avoid matching __dunder__ methods
-  - "\\*is\\*"
+  - "(?<!\\*)\\*(?!\\*)is(?<!\\*)\\*(?!\\*)"
   - " _is_"
-  - "\\*are\\*"
+  - "(?<!\\*)\\*(?!\\*)are(?<!\\*)\\*(?!\\*)"
   - " _are_"
-  - "\\*was\\*"
+  - "(?<!\\*)\\*(?!\\*)was(?<!\\*)\\*(?!\\*)"
   - " _was_"
-  - "\\*were\\*"
+  - "(?<!\\*)\\*(?!\\*)were(?<!\\*)\\*(?!\\*)"
   - " _were_"
 
   # Italicized "the" for false emphasis
-  - "\\*the\\*"
+  - "(?<!\\*)\\*(?!\\*)the(?<!\\*)\\*(?!\\*)"
   - " _the_"
 
   # Italicized single conjunctions/prepositions for false drama
   # Note: underscore patterns require space prefix to avoid matching __dunder__ methods
-  - "\\*and\\*"
+  - "(?<!\\*)\\*(?!\\*)and(?<!\\*)\\*(?!\\*)"
   - " _and_"
-  - "\\*not\\*"
+  - "(?<!\\*)\\*(?!\\*)not(?<!\\*)\\*(?!\\*)"
   - " _not_"
-  - "\\*or\\*"
+  - "(?<!\\*)\\*(?!\\*)or(?<!\\*)\\*(?!\\*)"
   - " _or_"
 
   # Italicized intensifiers, where the italics do the work the sentence should
@@ -34,15 +46,15 @@ tokens:
   # these without markup patterns, but it hard-fails on older Vale, so this
   # rule stays on `raw` until the inline-scope package lands.
   # Note: underscore patterns require space prefix to avoid matching __dunder__ methods
-  - "\\*actually\\*"
+  - "(?<!\\*)\\*(?!\\*)actually(?<!\\*)\\*(?!\\*)"
   - " _actually_"
-  - "\\*really\\*"
+  - "(?<!\\*)\\*(?!\\*)really(?<!\\*)\\*(?!\\*)"
   - " _really_"
-  - "\\*never\\*"
+  - "(?<!\\*)\\*(?!\\*)never(?<!\\*)\\*(?!\\*)"
   - " _never_"
-  - "\\*always\\*"
+  - "(?<!\\*)\\*(?!\\*)always(?<!\\*)\\*(?!\\*)"
   - " _always_"
-  - "\\*truly\\*"
+  - "(?<!\\*)\\*(?!\\*)truly(?<!\\*)\\*(?!\\*)"
   - " _truly_"
-  - "\\*literally\\*"
+  - "(?<!\\*)\\*(?!\\*)literally(?<!\\*)\\*(?!\\*)"
   - " _literally_"

--- a/test-false-positives.md
+++ b/test-false-positives.md
@@ -1486,3 +1486,13 @@ The proposal separates the surface syntax from the semantics.
 The lander touched the surface of the moon at dawn.
 
 Sand the top surface before you paint it.
+
+## EmphaticCopula: bold markup that should NOT trigger
+
+This design **is** intentional.
+
+The fix **actually** works as expected.
+
+We **never** skip the validation step.
+
+The report **always** posts on Fridays.


### PR DESCRIPTION
## Summary

Guards `EmphaticCopula`'s asterisk tokens so each needs one unpaired
asterisk. Bold markup no longer triggers a rule meant only for italics.

## Why

Every asterisk-wrapped token, `is`, `actually`, `never`, `always`, and
ten more, is a bare regular expression read against raw text. A
doubled asterisk still contains that same four-character shape:
`**word**` reads exactly like `*word*` to the old pattern, once you
count the outer pair in.

Confirmed as a false positive two ways. Empirically: `mise run
test-clean` against `This design **is** intentional.`, a sentence
using bold and no italics at all, still raised `ai-tells.EmphaticCopula`.
By the rule's own definition, too: its message reads "Remove the
italics," and bold-only text has none to remove. The alert appeared on
a Markdown convention this rule doesn't police.

GitHub user StevenACoffman found and fixed this same false positive
independently, in a personal fork of this repository, commit
513746064f8d4eef88978e287d7eb39674187335. ~That fork predates
`VerbTricolon`'s POS-tagged rewrite in #49 and the Vale 3.19.0 floor
that pull request set, so it avoided `lookbehind` for RE2
compatibility and consumed a neighboring character instead. This
change uses `lookbehind` and `lookahead` guards instead, matching the
negative `lookbehind` pattern `VerbTricolon`'s commit-subject
exemption already uses, under the same Vale version floor.~

## Open Question

`***word***` (bold-italic) falls outside the fix too, as a side effect
rather than a deliberate choice. The guard only recognizes one
unpaired asterisk on each side. Bold-italic has three on each side, so
it doesn't qualify either. Whether bold-italic should count as the
same manufactured-emphasis tell as plain italic is an open question
this PR doesn't resolve, flagged here rather than decided unilaterally.

## Verification

- Wrote the regression fixture first, in `test-false-positives.md`
  under a new `EmphaticCopula: bold markup that should NOT trigger`
  heading with four cases. Confirmed it failed against the rule
  before the fix: `mise run test-clean` reported exactly four errors,
  all `ai-tells.EmphaticCopula`, before any rule code changed.
- Applied the fix in `styles/ai-tells/EmphaticCopula.yml`. Re-ran
  `mise run test-clean`: zero errors.
- Confirmed no loss of true-positive coverage. The existing italic
  fixture in `test-document.md`, under its own `EmphaticCopula`
  heading, still fires on all four of its cases, checked directly
  against `.vale-test.ini` with JSON output.
- Ran the full suite, `mise run test`: test-fires, test-commit-past-tense,
  and test-clean all passed. `test-document.md` fired 1309 errors and
  `test-commit-messages.md` fired 122, both well past the 400/40
  floor, confirming the fix didn't shrink coverage.
- `mise run lint-messages` didn't report any findings against the
  rule's own message text.
- `mise run lint-commit-msg` passed clean on the paired commit, through
  commit-trailers, `commitlint`, the vale commit-message gate, and
  cspell.
- Vale version: 3.19.0. That matches the floor #49 set for rules that
  depend on `lookbehind` in this package.

## Risk

Low, and scoped to one rule. The change tightens only `EmphaticCopula`'s
asterisk tokens. Its eight underscore tokens stay as they were: bold
underscore markup never presents the space-prefixed literal those
tokens require. Worst case if this pattern is wrong: bold
text starts firing again, the same state as before this change, or
the rule stops firing on some italic phrasing the `test-document.md`
fixture doesn't cover. Either failure is a rule-quality problem, not a
crash, and `mise run test-clean` turns red if it recurs. To back out:
revert this commit. The added fixture is harmless to keep even
without the code fix, since it documents a case the rule doesn't yet
cover.

## Related

No open issue or pull request references this. Credit: GitHub user
StevenACoffman found and fixed the same false positive independently,
in commit 513746064f8d4eef88978e287d7eb39674187335 of a personal fork.
That fork has since fallen 73 commits behind `main`, and nobody merged
its fix here.
