### PR TITLE
docs(changelog): add the EmphaticCopula entry and fix the generated notes

### DIFF
--- a/.cspell-words.txt
+++ b/.cspell-words.txt
@@ -180,6 +180,7 @@ Tengo
 Tera
 testdata
 tfvars
+theredspoon
 throughlines
 tmpl
 tokeni

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **FigurativeSurfaces** (`ai-tells`): The bare verb behind a modal, an infinitive marker, or a negation now fires ("tooling to surface changes," "will surface reports," "can surface bugs," "doesn't surface the failure"). A documentation-corpus census found the uninflected form escaping, since every token read an inflected one. Thirteen hits across the seven pre-LLM corpora, each the figure.
 - **FigurativeNouns** (`ai-tells`): "Surface" as what a reader or a caller sees joins the noun list ("the prose surface," "its canonical surface," "a reader-facing surface," "the whole surface"), the census's second-ranked figurative noun with no rule reading it. The modifier slot refuses the exported-names term ("the API surface," "the attack surface," "its public surface") and the lookahead the physical and linguistic compounds ("surface area," "surface syntax," "the surface language," "the surface of the moon"); it fires seven times in the Rust RFCs and PEPs, five making the same figure and two on the bare "on the surface."
 
+### Fixed
+
+- **EmphaticCopula** (`ai-tells`): Bold markup no longer fires the rule. Every asterisk token was a bare regular expression, and a doubled-asterisk span contains the same four-character shape a single-asterisk one does, so a sentence carrying bold and no italics at all raised an alert whose message asked for italics to be removed. Each asterisk token now requires an unpaired asterisk on either side, which leaves single-asterisk emphasis as the only match and drops the bold-italic triple along with bold. The underscore tokens are unchanged, because a doubled-underscore run never contains the space-prefixed shape they require. A bold-markup case in `test-false-positives.md` covers the regression.
+
 <!-- vale on -->
 
 ## [1.33.0] - 2026-09-06

--- a/cog.toml
+++ b/cog.toml
@@ -9,6 +9,7 @@ owner = "aitells"
 authors = [
   { username = "aitellsbot", signature = "AI Tells Bot" },
   { username = "tbhb", signature = "Tony Burns" },
+  { username = "theredspoon", signature = "Nim G" },
 ]
 
 [commit_types]

--- a/cog.toml
+++ b/cog.toml
@@ -5,7 +5,7 @@ path = "CHANGELOG.md"
 template = "remote"
 remote = "github.com"
 repository = "vale-ai-tells"
-owner = "aitells"
+owner = "tbhb"
 authors = [
   { username = "aitellsbot", signature = "AI Tells Bot" },
   { username = "tbhb", signature = "Tony Burns" },


### PR DESCRIPTION
## Summary

The Unreleased section of `CHANGELOG.md` gains a Fixed entry for the EmphaticCopula bold-markup fix, and the changelog settings in `cog.toml` now name the current repository owner and map the contributor behind that fix to a GitHub account.

## Why

The EmphaticCopula fix landed with no changelog entry. Someone writes the Unreleased section by hand and the next release reads from it, so an entry exists only when somebody adds one.

The repository moved out of the `aitells` organization and nobody updated the `owner` setting, so every compare and commit URL cog builds for a release note addressed a path GitHub answers only through its move redirect. That redirect holds until somebody creates a repository at the old path. At the bottom of `CHANGELOG.md`, the link table has named `tbhb` all along, and the generated notes now agree with it.

cog's remote template links an author it has a mapping for to a GitHub profile and prints an author it has none for as the bare git name. Every author these notes have named so far resolves to a link, and a first-time contributor should get the same. That username then needs an entry in `.cspell-words.txt` so the spelling check passes.

## Verification

`cog changelog --at v1.33.0` and `cog changelog v1.33.0..HEAD` build their URLs under github.com/tbhb/vale-ai-tells, and the bug-fix line in the second credits `@theredspoon`. `cspell` over the changed files doesn't report anything and `mise run repotools:lint-toml` passes. `mise run lint-prose` never reads `CHANGELOG.md`, whose glob exclusion is there because cog regenerates that file wholesale.

## Risk

If the owner is still wrong, a generated release note points at a path that resolves only through the redirect, and the correction is another edit to `cog.toml`. A wrong author mapping puts the wrong profile link beside a commit in the next release note. Reverting this branch restores the previous settings and drops the changelog entry. The release zips take only what sits under `styles/`, so a published package is unaffected either way.

## Related

Records the EmphaticCopula fix from #64.
