### PR TITLE
docs(changelog): correct the overlap claim in the EmphaticCopula entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **EmphaticCopula** (`ai-tells`): Bold markup no longer fires the rule. Every asterisk token was a bare regular expression, and a doubled-asterisk span contains the same four-character shape a single-asterisk one does, so a sentence carrying bold and no italics at all raised an alert whose message asked for italics to be removed. Each asterisk token now requires an unpaired asterisk on either side, which leaves single-asterisk emphasis as the only match and drops the bold-italic triple along with bold. The underscore tokens are unchanged, because a doubled-underscore run never contains the space-prefixed shape they require. A bold-markup case in `test-false-positives.md` covers the regression.
+- **EmphaticCopula** (`ai-tells`): Bold markup no longer fires the rule. Every asterisk token was a bare regular expression, and a doubled-asterisk span contains the same shape a single-asterisk one does once the outer pair is counted in, so a sentence carrying bold and no italics at all raised an alert whose message asked for italics to be removed. Each asterisk token now requires an unpaired asterisk on either side, which leaves single-asterisk emphasis as the only match and drops the bold-italic triple along with bold. The underscore tokens are unchanged, because a doubled-underscore run never contains the space-prefixed shape they require. A bold-markup case in `test-false-positives.md` covers the regression.
 
 <!-- vale on -->
 


### PR DESCRIPTION
## Summary

The Unreleased entry for the **EmphaticCopula** fix described the bold and italic overlap as a four-character shape. The entry now states the overlap without a length. A doubled-asterisk span contains what a single-asterisk one contains, once you count the outer pair.

## Why

Only the two-letter tokens in the rule are four characters long. `styles/ai-tells/EmphaticCopula.yml` also matches the intensifier literally, whose token runs to eleven characters, so the entry stated a size most of the tokens never had. The delimiters work out the same whatever the asterisks enclose. The entry needed to say that.

## Verification

`mise run repotools:lint-markdown` passed. `mise run lint-prose` reported the same warnings that stand on `main` and no errors.

## Risk

A reader of the released notes gets a less precise account of the bold overlap than the corrected one, which is the extent of the risk. Reverting the commit restores the previous wording. No rule, fixture, or configuration changes here.

## Related

The entry describes the fix from #64, and #67 added it.
