### PR TITLE
build(attributes): exempt the codex marker document from the scan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,10 @@
 # toolchain bump's diff is the only place a reviewer sees them change.
 # Suppressed, a Renovate pin bump renders as `Bin NNNNN bytes`.
 mise.lock diff
+
+# marker-scan.sh exempts the resolve-rebase-conflicts SKILL.md by name,
+# because that document teaches the marker shape by showing it. The
+# codex twin shows the same block and the exemption does not reach it,
+# so every rebase verification reports three markers that are the
+# document's subject rather than an unfinished resolution.
+.claude/skills/codex-resolve-rebase-conflicts/SKILL.md conflict-markers=documented


### PR DESCRIPTION
## Summary

`.gitattributes` gains a `conflict-markers=documented` declaration for `.claude/skills/codex-resolve-rebase-conflicts/SKILL.md`, so the marker scan stops reporting the fenced block that document exists to print.

## Why

`.claude/skills/rebase/scripts/marker-scan.sh` reads a conflict marker as damage, and it spells out one exemption as a name match, because `.claude/skills/resolve-rebase-conflicts/SKILL.md` demonstrates the marker form by printing it. The copy under `.claude/skills/rebase/scripts/` names that one document, while the copy under `.claude/skills/codex-rebase/scripts/` names the codex twin beside it and returns before consulting the attribute for that path. Since the codex twin prints the same block, the false report came from the copy under `.claude/skills/rebase/scripts/` alone: it read marker lines that are the document's subject as an unfinished resolution. That copy is what `.claude/skills/rebase/scripts/verify-rebase.sh`, `.claude/skills/rebase/scripts/rebase-status.sh`, and `.claude/skills/rebase/scripts/continue-rebase.sh` each invoke, so each of them showed the report.

The script already reads a git attribute for this case, so the declaration goes where the script looks. Adding the codex path to the name list inside the script is the other answer, but that file is vendored from repotools, so the next sync overwrites it. Both the scanner and the document it misreads come from that package, so the exemption belongs upstream. In the meantime, a consumer can declare the attribute.

## Verification

`git check-attr conflict-markers -- .claude/skills/codex-resolve-rebase-conflicts/SKILL.md` reports `documented`, and `bash .claude/skills/rebase/scripts/marker-scan.sh` over that path now exits 0 with an empty report. The same script over a copy of that document at a scratch path outside the declaration reports the document's marker lines and exits 1, which is the report this change removes.

`grep -n` for the marker pattern against `.claude/skills/codex-resolve-rebase-conflicts/SKILL.md` puts every marker line inside the fenced example the document prints, so nothing the declaration currently hides is an unfinished resolution.

## Risk

The declaration suppresses a report, and it applies to one path. A wrong declaration would exempt an actual unfinished resolution inside that one document from the scan, and that document is prose about markers rather than anything that runs.

`.claude/skills/resolve-rebase-conflicts/scripts/guard-resolve.sh` reads the same attribute to decide whether to refuse a `git add`, so the declaration reaches that guard too. The effect there matches the intent: the guard now accepts a `git add` of the codex document despite the block it prints.

Backing it out means dropping the added block from `.gitattributes`. The diff touches that file alone.

## Related

None.
