### PR TITLE
fix(rules): read the bare object forms of the kept-honest figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Metacommentary** and **MicDrop** (`ai-tells`): The "This is the point" token and the "And that's the point." coda moved to `PointVerdict`, which reads the whole copula family, so one span reports under one rule.
 
+### Fixed
+
+- **EnforcementMetaphors** (`ai-tells`): The kept-honest family now reads a bare demonstrative, a second-person or first-person object, and the reflexives ("keeps this honest," "keeps that honest," "keeps you honest," "keep ourselves honest," "keep everything honest"). The pronoun token listed five words and the determiner token required a noun after "this," so the bare demonstrative passed between them. The new forms match twice across the seven pre-LLM corpora, a Go proposal's linker that will "keep everything honest" and a Go comment stripping a variable "to keep ourselves honest," each the figure.
+
 <!-- vale on -->
 
 ## [1.34.0] - 2026-09-07

--- a/styles/ai-tells/EnforcementMetaphors.yml
+++ b/styles/ai-tells/EnforcementMetaphors.yml
@@ -38,12 +38,17 @@ tokens:
   - "\\bfight(?:s|ing)? (?:the|a|an|its) [a-z]+ for\\b"
 
   # --- Kept honest: a check as the conscience ("the gates that keep them
-  # honest," "keeps a before-and-after comparison honest"). The one
-  # standard-library match is a Go comment using the same figure, so it
-  # fires by design. The object slot admits up to three words after a
-  # documentation-corpus audit (2026-09) found the compound object
-  # escaping.
-  - "\\bke(?:eps?|eping|pt) (?:it|them|us|everyone|everybody) honest\\b"
+  # honest," "keeps a before-and-after comparison honest," "keeps this
+  # honest"). The one standard-library match is a Go comment using the
+  # same figure, so it fires by design. The object slot admits up to
+  # three words after a documentation-corpus audit (2026-09) found the
+  # compound object escaping. The bare demonstrative and reflexive
+  # objects ("keeps this honest," "keep ourselves honest") sat between
+  # the two tokens until the maintainer spotted one; they match twice
+  # more across the seven pre-LLM corpora, a Go proposal's linker that
+  # will "keep everything honest" and a Go comment stripping a variable
+  # "to keep ourselves honest," each the figure.
+  - "\\bke(?:eps?|eping|pt) (?:it|them|us|me|you|this|that|these|those|things|everything|everyone|everybody|itself|myself|yourself|ourselves|themselves) honest\\b"
   - "\\bke(?:eps?|eping|pt) (?:the|a|an|its|every|each|this|that|these|those|all|both) (?:[a-z'-]+ ){1,3}honest\\b"
 
   # --- Honest numbers: candor credited to a count ("an honest count,"

--- a/test-document.md
+++ b/test-document.md
@@ -2254,6 +2254,12 @@ The gates keep them honest between releases.
 
 The hooks keep the whole pipeline honest.
 
+The corpus check keeps this honest.
+
+The linker will keep everything honest.
+
+We strip it out to keep ourselves honest.
+
 No fingerprint stands behind that grant.
 
 One skill stood in the way of a documented command.


### PR DESCRIPTION
## Summary

`EnforcementMetaphors` now reports the kept-honest figure when its object is a bare demonstrative, a first-person or second-person pronoun, a reflexive among `itself`, `myself`, `yourself`, `ourselves`, and `themselves`, or an indefinite such as `everything`. The rule comment records where the new forms match on the pre-LLM corpora, and `test-document.md` gains fixtures for the bare demonstrative, the indefinite, and the reflexive.

## Why

The kept-honest family split the object slot across a short pronoun token and a determiner-plus-noun token. `keeps this check honest` matched the second, but `keeps this honest` matched neither, because the pronoun list did not include the demonstratives and the determiner token required a noun after `this`. Whether a sentence reported depended on whether a noun followed the demonstrative, and the rule reads the figure regardless of its object. Reflexives and the indefinite objects had the same problem: both tokens skipped them.

On the pre-LLM corpora, the new forms match a Go proposal describing what its linker does for every symbol and a Go comment explaining why the code strips a variable from an environment. Both are the figure the rule exists to report, and the rule comment records each hit beside the tokens.

## Verification

`mise run corpus-grep '\bke(eps?|eping|pt) (me|you|this|that|these|those|things|everything|itself|myself|yourself|ourselves|themselves) honest\b'` measured the object forms the token adds. It reported one hit in the Go proposals, the linker that is to `keep everything honest`, one in the Go standard library, the comment that strips a variable `to keep ourselves honest`, and none in the other five corpora. Over the old list, `it|them|us|everyone|everybody`, the same task reported the one standard-library hit the rule comment already recorded and nothing else.

`mise run test` passed, with the new fixtures firing under `EnforcementMetaphors` and nothing firing in `test-false-positives.md`. The lint pass, `mise run lint`, exited clean. The prose warnings it prints are on documentation files this branch leaves alone, none of them under `styles/` or in the fixtures. `vale --config=.vale.ini --output=ai-tells-agent.tmpl test-document.md` reports `keeps this honest`, `keep everything honest`, and `keep ourselves honest` under the rule at the new fixture lines.

## Risk

The added objects are the demonstratives, the first-person and second-person pronouns, the reflexives `itself`, `myself`, `yourself`, `ourselves`, and `themselves`, and the two indefinite objects `things` and `everything`. The third-person `himself` and `herself` and the plural `yourselves` stay out of the token, so the figure with one of those as its object still passes. Only `things` is a noun, a fixed bare plural with no open noun slot. If a hit turns out to be literal prose, a user adds an exception in their own `.vale.ini`, which is the project's stance on every rule. Reverting the commit restores the short pronoun list and removes the fixtures and the CHANGELOG entry with it.

## Related

None
